### PR TITLE
Partnership and backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Database backups
+backups/

--- a/backup_db.sh
+++ b/backup_db.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Resolve project root from script location (portable across machines).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Load environment variables from local .env.
+if [[ ! -f ".env" ]]; then
+  echo "Error: .env file not found in $SCRIPT_DIR" >&2
+  exit 1
+fi
+set -a
+source ".env"
+set +a
+
+if [[ -z "${DATABASE_URL_PROD:-}" ]]; then
+  echo "Error: DATABASE_URL_PROD is not set in .env" >&2
+  exit 1
+fi
+
+if ! command -v pg_dump >/dev/null 2>&1; then
+  echo "Error: pg_dump not found in PATH." >&2
+  echo "Install PostgreSQL client tools or set PATH to include pg_dump." >&2
+  exit 1
+fi
+
+# Create backup directory and timestamped filename
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+BACKUP_DIR="backups"
+mkdir -p "$BACKUP_DIR"
+
+# Backup database
+# Note: pg_dump major version must be compatible with the PostgreSQL server major version.
+# If you see a version mismatch error, install/use the matching PostgreSQL client tools.
+# As of 2026-04-22, the pg_dump version is 18.3 (Ubuntu 18.3-1.pgdg24.04+1) and the PostgreSQL server version is 17.8 (a48d9ca)
+echo "Using pg_dump: $(command -v pg_dump)"
+pg_dump --version
+pg_dump "$DATABASE_URL_PROD" --clean --no-owner --no-acl -f "$BACKUP_DIR/backup_${TIMESTAMP}.sql"
+
+echo "Backup created at: $BACKUP_DIR/backup_${TIMESTAMP}.sql"

--- a/partnerships/partnerships.json
+++ b/partnerships/partnerships.json
@@ -199,15 +199,13 @@
             "company": "",
             "role": "",
             "criteria": [
-                { "type": "product_opinion", "count": 1 },
+                { "type": "initiative", "count": 1 },
                 { "type": "above_and_beyond", "count": 1 },
                 { "type": "propose_implementation_plan", "count": 1 },
                 { "type": "blog_post", "count": 1 },
                 { "type": "receive_feedback", "count": 1 },
-                { "type": "issue", "count": 5 },
-                { "type": "same_project_issue", "count": 5 }
+                { "type": "issue", "count": 5 }
             ]
         }
-
     ]
 }   

--- a/partnerships/partnerships.json
+++ b/partnerships/partnerships.json
@@ -191,6 +191,22 @@
                 { "type": "issue", "count": 6 },
                 { "type": "impact_video_demo", "count": 1} 
             ]
+        },
+        {
+            "id": 13, 
+            "name": "Piranavan S.",
+            "linkedIn": "",
+            "company": "",
+            "role": "",
+            "criteria": [
+                { "type": "product_opinion", "count": 1 },
+                { "type": "above_and_beyond", "count": 1 },
+                { "type": "propose_implementation_plan", "count": 1 },
+                { "type": "blog_post", "count": 1 },
+                { "type": "receive_feedback", "count": 1 },
+                { "type": "issue", "count": 5 },
+                { "type": "same_project_issue", "count": 5 }
+            ]
         }
 
     ]

--- a/partnerships/types.json
+++ b/partnerships/types.json
@@ -546,6 +546,22 @@
                 "text": "Write a 1 sentence description of the project and how it relates to the video streaming space: "
             }
             ]
+        },
+        "same_project_issue": {
+            "is_primary": false,
+            "short_name": "same_project_issue",
+            "quality": "Growth and Commitment", 
+            "metric": "Reasonably challenging issue from the same project", 
+            "plan_column_fields": [],
+            "baby_step_column_fields": [{
+                "type": "checkbox",
+                "text": "Helper video is coming soon...",
+                "helper_video": "" 
+            }],
+            "proof_of_completion_column_fields": [{
+                "type": "checkbox",
+                "text": "Did you solve the issue within the same project and includes some variety in the size of the issues (2 medium sized issues and/or one large issue and not all small issues)?"
+            }]
         }
     }   
 }

--- a/partnerships/types.json
+++ b/partnerships/types.json
@@ -546,22 +546,6 @@
                 "text": "Write a 1 sentence description of the project and how it relates to the video streaming space: "
             }
             ]
-        },
-        "same_project_issue": {
-            "is_primary": false,
-            "short_name": "same_project_issue",
-            "quality": "Growth and Commitment", 
-            "metric": "Reasonably challenging issue from the same project", 
-            "plan_column_fields": [],
-            "baby_step_column_fields": [{
-                "type": "checkbox",
-                "text": "Helper video is coming soon...",
-                "helper_video": "" 
-            }],
-            "proof_of_completion_column_fields": [{
-                "type": "checkbox",
-                "text": "Did you solve the issue within the same project and includes some variety in the size of the issues (2 medium sized issues and/or one large issue and not all small issues)?"
-            }]
         }
     }   
 }


### PR DESCRIPTION
## Backup Logic Changes

- Improved `backup_db.sh` to be safer and more portable across developer environments.
- Added strict shell behavior with `set -euo pipefail` to fail fast on errors.
- Resolved script execution from its own directory before loading `.env` to avoid path-dependent failures.
- Added checks for required config and tools:
  - `.env` exists
  - `DATABASE_URL_PROD` is set
  - `pg_dump` is available
- Standardized backup output to timestamped files under `backups/`.
- Added clear runtime output for `pg_dump` path/version and output file location.
- Added `backups/` to `.gitignore` to avoid committing generated SQL backup files.

## Partnerships and Types

- Added new partnership entry, P.S. in `partnerships/partnerships.json`.
- Added/updated type definitions in `partnerships/types.json` (`same_project_issue`).
- Kept style consistent with existing partnership/type objects (quality, metric, fields, and proof-of-completion metadata)... hopefully.

## Tested

- Verified backup script runs successfully and creates timestamped SQL output in `backups/`.
- Verified app functionality remained intact after backup/tooling updates.

## How to Test

- Testing backup script, try to run: `./backup_db.sh` in your terminal.
  - If postgresql version mismatch, update your postgresql to >=17.
- Testing new partnership, [test here](https://offer-insight-swart.vercel.app/)
  - Make sure to seed it if testing locally, otherwise, skip this step.
  - Best to sign in as instructor00, test on dev's 'test' account, choose P.S. as partnership.
  - See if it's to your satisfaction how I did the partnership and extra.