### PR TITLE
View active cards fix

### DIFF
--- a/app/api/open_source/route.ts
+++ b/app/api/open_source/route.ts
@@ -1,8 +1,35 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/db";
 import { canMutateUserDataForRequest, getUserIdForRequest } from "@/app/lib/api-user-helper";
+import { normalizePartnerName } from "@/app/lib/partnership-name";
 
-// GET: Fetch all open source entries for a user
+/** Resolves the active enrollment for this user when the program name matches. */
+async function resolveUserPartnershipIdForCreate(
+  userId: string,
+  partnershipName: string,
+  explicitId: unknown
+): Promise<number | null> {
+  if (typeof explicitId === "number" && Number.isInteger(explicitId) && explicitId > 0) {
+    const up = await prisma.userPartnership.findFirst({
+      where: { id: explicitId, userId },
+    });
+    if (up) return up.id;
+  }
+  const active = await prisma.userPartnership.findFirst({
+    where: { userId, status: "active" },
+    include: { partnership: true },
+  });
+  if (
+    active &&
+    normalizePartnerName(active.partnership.name) === normalizePartnerName(partnershipName)
+  ) {
+    return active.id;
+  }
+  return null;
+}
+
+// GET: All entries for the user, or for one enrollment (FK + optional legacy name OR).
+// ?enrollment=<UserPartnership.id> — repeat &name=... for legacy cards with null `userPartnerhipId`.
 export async function GET(request: NextRequest) {
   try {
     const { userId, error } = await getUserIdForRequest(request);
@@ -11,9 +38,47 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: error || "Unauthorized" }, { status: 401 });
     }
 
+    const url = new URL(request.url);
+    const enrollmentParam = url.searchParams.get("enrollment");
+    const nameAliases = url.searchParams
+      .getAll("name")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    if (enrollmentParam != null && enrollmentParam !== "") {
+      const enrollmentId = parseInt(enrollmentParam, 10);
+      if (Number.isNaN(enrollmentId) || enrollmentId < 1) {
+        return NextResponse.json({ error: "Invalid enrollment" }, { status: 400 });
+      }
+      const up = await prisma.userPartnership.findFirst({
+        where: { id: enrollmentId, userId },
+      });
+      if (!up) {
+        return NextResponse.json({ error: "Enrollment not found" }, { status: 404 });
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const orClauses: any[] = [{ userPartnershipId: enrollmentId }];
+      if (nameAliases.length > 0) {
+        orClauses.push({
+          userPartnershipId: null,
+          OR: nameAliases.map((name) => ({
+            partnershipName: { equals: name, mode: "insensitive" as const },
+          })),
+        });
+      }
+
+      const entries = await prisma.openSourceEntry.findMany({
+        where: { userId, OR: orClauses },
+        orderBy: { dateCreated: "desc" },
+      });
+
+      return NextResponse.json(entries);
+    }
+
     const entries = await prisma.openSourceEntry.findMany({
       where: { userId },
-      orderBy: { dateCreated: 'desc' },
+      orderBy: { dateCreated: "desc" },
     });
 
     return NextResponse.json(entries);
@@ -42,6 +107,12 @@ export async function POST(request: NextRequest) {
 
     const data = await request.json();
 
+    const userPartnershipId = await resolveUserPartnershipIdForCreate(
+      userId,
+      String(data.partnershipName ?? ""),
+      data.userPartnershipId
+    );
+
     const entry = await prisma.openSourceEntry.create({
       data: {
         partnershipName: data.partnershipName,
@@ -56,6 +127,7 @@ export async function POST(request: NextRequest) {
         proofOfCompletion: data.proofOfCompletion || [],
         proofResponses: data.proofResponses || {},
         userId: userId,
+        ...(userPartnershipId != null ? { userPartnershipId } : {}),
         dateCreated: data.dateCreated ? new Date(data.dateCreated) : new Date(),
         dateModified: new Date(),
       },

--- a/app/api/open_source/route.ts
+++ b/app/api/open_source/route.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/db";
 import { canMutateUserDataForRequest, getUserIdForRequest } from "@/app/lib/api-user-helper";
@@ -29,7 +30,7 @@ async function resolveUserPartnershipIdForCreate(
 }
 
 // GET: All entries for the user, or for one enrollment (FK + optional legacy name OR).
-// ?enrollment=<UserPartnership.id> — repeat &name=... for legacy cards with null `userPartnerhipId`.
+// ?enrollment=<UserPartnership.id> — repeat &name=... for legacy rows with null `userPartnershipId`.
 export async function GET(request: NextRequest) {
   try {
     const { userId, error } = await getUserIdForRequest(request);
@@ -57,8 +58,9 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: "Enrollment not found" }, { status: 404 });
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const orClauses: any[] = [{ userPartnershipId: enrollmentId }];
+      const orClauses: Prisma.OpenSourceEntryWhereInput[] = [
+        { userPartnershipId: enrollmentId },
+      ];
       if (nameAliases.length > 0) {
         orClauses.push({
           userPartnershipId: null,

--- a/app/api/users/partnership/route.ts
+++ b/app/api/users/partnership/route.ts
@@ -189,12 +189,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // If instructor is switching partnerships, abandon the old one and delete all cards
+    // If instructor is switching partnerships, delete only that program's open-source cards, then maybe abandon
     // This happens BEFORE creating the new one to ensure proper count tracking
     if (existingActive && isInstructor) {
-      // Delete all open source entries for this user
+      // Only remove cards for the active enrollment (keep completed / other history)
       await prisma.openSourceEntry.deleteMany({
-        where: { userId },
+        where: { userId, userPartnershipId: existingActive.id },
       });
 
       // Abandon the old partnership (only if switching to a different one)
@@ -267,6 +267,7 @@ export async function POST(request: NextRequest) {
                 await tx.openSourceEntry.create({
                   data: {
                     userId,
+                    userPartnershipId: newPartnership.id,
                     partnershipName: partnershipDef.name,
                     criteriaType: selectedChoice.type,
                     metric: typeDef?.metric || selectedChoice.type,
@@ -294,6 +295,7 @@ export async function POST(request: NextRequest) {
               await tx.openSourceEntry.create({
                 data: {
                   userId,
+                  userPartnershipId: newPartnership.id,
                   partnershipName: partnershipDef.name,
                   criteriaType: criteria.type,
                   metric: typeDef.metric || criteria.type,
@@ -464,9 +466,8 @@ export async function DELETE(request: NextRequest) {
 
     // Delete all cards and abandon partnership
     await prisma.$transaction(async (tx) => {
-      // Delete all open source entries for this user
       await tx.openSourceEntry.deleteMany({
-        where: { userId },
+        where: { userId, userPartnershipId: activePartnership.id },
       });
 
       // Abandon the partnership

--- a/app/dashboard/components/OpenSourceTab.tsx
+++ b/app/dashboard/components/OpenSourceTab.tsx
@@ -44,7 +44,12 @@ type OpenSourceTabProps = {
   fullPartnerships: Array<{ id: number; name: string; criteria?: any[] }>;
   fetchAvailablePartnerships: () => Promise<void>;
   refreshCompletedPartnerships?: () => Promise<void>;
-  completedPartnerships?: Array<{ id: number; partnershipName: string; criteria: any[] }>;
+  completedPartnerships?: Array<{
+    id: number;
+    partnershipId: number;
+    partnershipName: string;
+    criteria: any[];
+  }>;
   viewingCompletedPartnershipName?: string | null;
   setViewingCompletedPartnershipName?: (name: string | null) => void;
   isInstructor?: boolean;

--- a/app/dashboard/components/types.ts
+++ b/app/dashboard/components/types.ts
@@ -64,6 +64,8 @@ export type InPersonEvent = {
 export type OpenSourceEntry = {
   id: number;
   partnershipName: string;
+  /** Ties the card to a `UserPartnership` enrollment; null for legacy or unmatched rows. */
+  userPartnershipId?: number | null;
   criteriaType?: string | null;
   metric?: string | null;
   status: OpenSourceStatus;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -40,32 +40,11 @@ import {
   APPLICATION_COMPLETION_COLUMNS,
   EVENT_COMPLETION_COLUMNS,
 } from './components/types';
-import partnershipsData from '@/partnerships/partnerships.json';
-
-/** Trims and lowercases for resilient matching when DB/JSON/Partnership.name drift. */
-function normalizePartnerName(s: string | null | undefined): string {
-  return (s ?? '').trim().toLowerCase();
-}
-
-/** All known string forms for a partnership (display name, JSON, API lists) — no DB column changes. */
-function buildPartnershipNameMatchSet(
-  partnershipId: number | null,
-  displayName: string | null,
-  availablePartnerships: Array<{ id: number; name: string }>,
-  fullPartnerships: Array<{ id: number; name: string }>
-): Set<string> {
-  const out = new Set<string>();
-  if (displayName) out.add(normalizePartnerName(displayName));
-  if (partnershipId != null) {
-    const fromJson = partnershipsData.partnerships.find(p => p.id === partnershipId)?.name;
-    if (fromJson) out.add(normalizePartnerName(fromJson));
-    const fromAvail = availablePartnerships.find(p => p.id === partnershipId)?.name;
-    if (fromAvail) out.add(normalizePartnerName(fromAvail));
-    const fromFull = fullPartnerships.find(p => p.id === partnershipId)?.name;
-    if (fromFull) out.add(normalizePartnerName(fromFull));
-  }
-  return out;
-}
+import { normalizePartnerName } from '@/app/lib/partnership-name';
+import {
+  buildPartnershipNameMatchSet,
+  getPartnershipNameAliasStrings,
+} from '@/app/lib/partnership-aliases';
 
 function openSourceDateForMonthFilter(entry: OpenSourceEntry): string | null {
   return entry.dateModified ?? entry.dateCreated ?? null;
@@ -106,6 +85,26 @@ function openSourceEntryMatchesNameSet(
   const n = normalizePartnerName(entry.partnershipName);
   if (n === '') return isActiveView;
   return nameSet.has(n);
+}
+
+/** When `enrollmentId` is set, prefer `userPartnershipId`; otherwise fall back to name matching. */
+function openSourceEntryMatchesProgram(
+  entry: OpenSourceEntry,
+  enrollmentId: number | null,
+  nameSet: Set<string> | null,
+  isActiveView: boolean
+): boolean {
+  if (enrollmentId != null) {
+    if (entry.userPartnershipId != null) {
+      return entry.userPartnershipId === enrollmentId;
+    }
+    if (nameSet && nameSet.size > 0) {
+      return openSourceEntryMatchesNameSet(entry, nameSet, isActiveView);
+    }
+    return false;
+  }
+  if (!nameSet || nameSet.size === 0) return true;
+  return openSourceEntryMatchesNameSet(entry, nameSet, isActiveView);
 }
 
 // ===== MOCK DATA FEATURE TOGGLE START =====
@@ -696,6 +695,11 @@ const hasSeededMockDataRef = useRef(false);
     Array<{ id: number; partnershipId: number; partnershipName: string; criteria: any[] }>
   >([]);
   const [viewingCompletedPartnershipName, setViewingCompletedPartnershipName] = useState<string | null>(null);
+  /** Set after each successful open-source list fetch; when enrollment matches the UI, client skips redundant program matching. */
+  const [openSourceListScope, setOpenSourceListScope] = useState<{
+    mode: 'all' | 'enrollment';
+    enrollmentId: number | null;
+  }>({ mode: 'all', enrollmentId: null });
   const [availablePartnerships, setAvailablePartnerships] = useState<Array<{ id: number; name: string; spotsRemaining: number }>>([]);
   const [fullPartnerships, setFullPartnerships] = useState<Array<{ id: number; name: string }>>([]);
   const isFetchingOpenSourceRef = useRef(false);
@@ -703,6 +707,56 @@ const hasSeededMockDataRef = useRef(false);
   const isFetchingAvailablePartnershipsRef = useRef(false);
   const isDraggingOpenSourceRef = useRef(false);
   const [showProofOfWorkWarning, setShowProofOfWorkWarning] = useState(false);
+
+  /** When we have a stable `UserPartnerhip` id + aliases, request only those rows (server filter). */
+  const openSourceFetchQuery = useMemo(():
+    | { type: 'all' }
+    | { type: 'enrollment'; enrollmentId: number; nameAliases: string[] } => {
+    if (!selectedPartnership) {
+      return { type: 'all' };
+    }
+    if (viewingCompletedPartnershipName) {
+      const cp = completedPartnerships.find(
+        c =>
+          normalizePartnerName(c.partnershipName) ===
+          normalizePartnerName(viewingCompletedPartnershipName)
+      );
+      if (!cp) {
+        return { type: 'all' };
+      }
+      return {
+        type: 'enrollment',
+        enrollmentId: cp.id,
+        nameAliases: getPartnershipNameAliasStrings(
+          cp.partnershipId,
+          viewingCompletedPartnershipName,
+          availablePartnerships,
+          fullPartnerships
+        ),
+      };
+    }
+    if (activePartnershipDbId == null) {
+      return { type: 'all' };
+    }
+    return {
+      type: 'enrollment',
+      enrollmentId: activePartnershipDbId,
+      nameAliases: getPartnershipNameAliasStrings(
+        selectedPartnershipId,
+        selectedPartnership,
+        availablePartnerships,
+        fullPartnerships
+      ),
+    };
+  }, [
+    selectedPartnership,
+    viewingCompletedPartnershipName,
+    completedPartnerships,
+    activePartnershipDbId,
+    selectedPartnershipId,
+    availablePartnerships,
+    fullPartnerships,
+  ]);
 
   const fetchOpenSourceEntries = useCallback(async () => {
     // --- MOCK DATA BYPASS FOR OPENSOURCE FETCH START ---
@@ -713,7 +767,19 @@ const hasSeededMockDataRef = useRef(false);
     try {
       isFetchingOpenSourceRef.current = true;
       setIsLoadingOpenSource(true);
-        const url = userIdParam ? `/api/open_source?userId=${userIdParam}` : '/api/open_source';
+      const params = new URLSearchParams();
+      if (userIdParam) {
+        params.set('userId', userIdParam);
+      }
+      if (openSourceFetchQuery.type === 'enrollment') {
+        params.set('enrollment', String(openSourceFetchQuery.enrollmentId));
+        for (const a of openSourceFetchQuery.nameAliases) {
+          params.append('name', a);
+        }
+      }
+      const qs = params.toString();
+      const url = `/api/open_source${qs ? `?${qs}` : ''}`;
+
       const response = await fetch(url);
       if (!response.ok) {
         // Do not wipe the board on transient 401/503 (e.g. session not ready) — that hid real DB rows in prod.
@@ -738,6 +804,15 @@ const hasSeededMockDataRef = useRef(false);
         grouped[column].push(entry);
       });
 
+      if (openSourceFetchQuery.type === 'enrollment') {
+        setOpenSourceListScope({
+          mode: 'enrollment',
+          enrollmentId: openSourceFetchQuery.enrollmentId,
+        });
+      } else {
+        setOpenSourceListScope({ mode: 'all', enrollmentId: null });
+      }
+
       setOpenSourceColumns(grouped);
     } catch (error) {
       console.error('Error fetching open source entries:', error);
@@ -745,7 +820,7 @@ const hasSeededMockDataRef = useRef(false);
       setIsLoadingOpenSource(false);
       isFetchingOpenSourceRef.current = false;
     }
-  }, [userIdParam]);
+  }, [userIdParam, openSourceFetchQuery]);
 
   useEffect(() => {
     // --- MOCK DATA BYPASS FOR OPENSOURCE EFFECT START ---
@@ -781,9 +856,9 @@ const hasSeededMockDataRef = useRef(false);
         setActivePartnershipDbId(data.active.id);
         setActivePartnershipCriteria(data.active.criteria || []);
         // Do not clear completed-view here: refetch runs often and would undo a click on history.
-      } else if (completed.length > 0) {
+      } else if (Array.isArray(data.completed) && data.completed.length > 0) {
         // No active partnership, but there are completed ones - show the most recent completed
-        const mostRecent = completed[0]; // Already sorted by completedAt desc from API
+        const mostRecent = data.completed[0]; // Already sorted by completedAt desc from API
         setSelectedPartnership(mostRecent.partnershipName);
         setSelectedPartnershipId(null); // No active partnership ID
         setActivePartnershipDbId(null);
@@ -1519,6 +1594,33 @@ const hasSeededMockDataRef = useRef(false);
       });
     }
 
+    let enrollmentFilterId: number | null = null;
+    if (viewingCompletedPartnershipName) {
+      const cp = completedPartnerships.find(
+        c => normalizePartnerName(c.partnershipName) === normalizePartnerName(viewingCompletedPartnershipName)
+      );
+      enrollmentFilterId = cp?.id ?? null;
+    } else if (selectedPartnership) {
+      enrollmentFilterId = activePartnershipDbId;
+    }
+
+    const isActiveView = Boolean(selectedPartnership && !viewingCompletedPartnershipName);
+
+    const skipProgramFilter =
+      openSourceListScope.mode === 'enrollment' &&
+      openSourceListScope.enrollmentId != null &&
+      openSourceListScope.enrollmentId === enrollmentFilterId;
+
+    if (skipProgramFilter) {
+      return {
+        timeFiltered,
+        nameSet: null,
+        isActiveView,
+        enrollmentFilterId,
+        skipProgramFilter: true as const,
+      };
+    }
+
     let nameSet: Set<string> | null = null;
     if (viewingCompletedPartnershipName) {
       const cp = completedPartnerships.find(
@@ -1543,9 +1645,13 @@ const hasSeededMockDataRef = useRef(false);
       nameSet = withAugmentNameSetForActiveSingleDistinct(nameSet, timeFiltered);
     }
 
-    const isActiveView = Boolean(selectedPartnership && !viewingCompletedPartnershipName);
-
-    return { timeFiltered, nameSet, isActiveView };
+    return {
+      timeFiltered,
+      nameSet,
+      isActiveView,
+      enrollmentFilterId,
+      skipProgramFilter: false as const,
+    };
   }, [
     openSourceColumns,
     openSourceFilter,
@@ -1556,24 +1662,32 @@ const hasSeededMockDataRef = useRef(false);
     availablePartnerships,
     fullPartnerships,
     isWithinCurrentMonth,
+    activePartnershipDbId,
+    openSourceListScope,
   ]);
 
   const openSourceCriteria = useMemo(() => {
     const doneEntries = openSourceColumns.done ?? [];
-    const { nameSet, isActiveView } = openSourceNameFilterState;
+    const { nameSet, isActiveView, enrollmentFilterId, skipProgramFilter } = openSourceNameFilterState;
     const totalCriteria = activePartnershipCriteria.reduce((sum, criteria) => {
       const count = Number(criteria?.count);
       return sum + (Number.isFinite(count) && count > 0 ? count : 1);
     }, 0);
-    const activePartnershipDoneCount =
-      nameSet && nameSet.size > 0
-        ? doneEntries
-            .filter(entry => openSourceEntryMatchesNameSet(entry, nameSet, isActiveView))
-            .reduce((sum, entry) => {
-              const extras = Array.isArray(entry.selectedExtras) ? entry.selectedExtras.length : 0;
-              return sum + 1 + extras;
-            }, 0)
-        : 0;
+    const hasProgramFilter =
+      skipProgramFilter ||
+      enrollmentFilterId != null ||
+      (nameSet != null && nameSet.size > 0);
+    const activePartnershipDoneCount = hasProgramFilter
+      ? (skipProgramFilter
+          ? doneEntries
+          : doneEntries.filter(entry =>
+              openSourceEntryMatchesProgram(entry, enrollmentFilterId, nameSet, isActiveView)
+            )
+        ).reduce((sum, entry) => {
+        const extras = Array.isArray(entry.selectedExtras) ? entry.selectedExtras.length : 0;
+        return sum + 1 + extras;
+      }, 0)
+      : 0;
     const completedCriteria =
       totalCriteria > 0 ? Math.min(activePartnershipDoneCount, totalCriteria) : activePartnershipDoneCount;
 
@@ -1636,7 +1750,11 @@ const hasSeededMockDataRef = useRef(false);
   }, [eventColumns, eventsFilter, isWithinCurrentMonth]);
 
   const filteredOpenSourceColumns = useMemo(() => {
-    const { timeFiltered, nameSet, isActiveView } = openSourceNameFilterState;
+    const { timeFiltered, nameSet, isActiveView, enrollmentFilterId, skipProgramFilter } =
+      openSourceNameFilterState;
+    if (skipProgramFilter) {
+      return timeFiltered;
+    }
     const filtered: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
       plan: [...timeFiltered.plan],
       babyStep: [...timeFiltered.babyStep],
@@ -1644,10 +1762,12 @@ const hasSeededMockDataRef = useRef(false);
       done: [...timeFiltered.done],
     };
 
-    if (nameSet && nameSet.size > 0) {
+    const hasProgramFilter =
+      enrollmentFilterId != null || (nameSet != null && nameSet.size > 0);
+    if (hasProgramFilter) {
       (Object.keys(filtered) as OpenSourceColumnId[]).forEach(columnId => {
         filtered[columnId] = filtered[columnId].filter(entry =>
-          openSourceEntryMatchesNameSet(entry, nameSet, isActiveView)
+          openSourceEntryMatchesProgram(entry, enrollmentFilterId, nameSet, isActiveView)
         );
       });
     }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -52,12 +52,12 @@ function openSourceDateForMonthFilter(entry: OpenSourceEntry): string | null {
 
 function mapCompletedPartnershipsFromApi(
   completed: { id: number; partnershipId: number; partnershipName: string; criteria: unknown }[]
-) {
-  return (completed || []).map((p) => ({
+): Array<{ id: number; partnershipId: number; partnershipName: string; criteria: any[] }> {
+  return (completed || []).map(p => ({
     id: p.id,
     partnershipId: p.partnershipId,
     partnershipName: p.partnershipName,
-    criteria: p.criteria || [],
+    criteria: Array.isArray(p.criteria) ? p.criteria : [],
   }));
 }
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -780,15 +780,44 @@ const hasSeededMockDataRef = useRef(false);
       const qs = params.toString();
       const url = `/api/open_source${qs ? `?${qs}` : ''}`;
 
-      const response = await fetch(url);
-      if (!response.ok) {
-        // Do not wipe the board on transient 401/503 (e.g. session not ready) — that hid real DB rows in prod.
-        console.warn('Open source fetch failed:', response.status, response.statusText);
-        return;
+      const fullListUrl = userIdParam
+        ? `/api/open_source?userId=${encodeURIComponent(userIdParam)}`
+        : '/api/open_source';
+
+      const first = await fetch(url);
+      let rows: OpenSourceEntry[] = [];
+      if (first.ok) {
+        const j: unknown = await first.json();
+        if (Array.isArray(j)) {
+          rows = j as OpenSourceEntry[];
+        }
       }
-      const data = await response.json();
-      if (!Array.isArray(data)) {
-        console.error('Open source: expected array', data);
+
+      const usedScopedUrl = openSourceFetchQuery.type === 'enrollment';
+      const tryFullListFallback = usedScopedUrl && (!first.ok || rows.length === 0);
+      let scopeMode: 'all' | 'enrollment' = 'all';
+      let scopeEnroll: number | null = null;
+      if (openSourceFetchQuery.type === 'enrollment') {
+        scopeEnroll = openSourceFetchQuery.enrollmentId;
+        scopeMode = 'enrollment';
+      }
+
+      if (tryFullListFallback) {
+        const second = await fetch(fullListUrl);
+        if (second.ok) {
+          const j: unknown = await second.json();
+          if (Array.isArray(j)) {
+            rows = j as OpenSourceEntry[];
+            // Revert to unscoped list; client `openSourceNameFilterState` filters by name / FK
+            scopeMode = 'all';
+            scopeEnroll = null;
+          }
+        } else if (!first.ok) {
+          console.warn('Open source fetch failed:', first.status, first.statusText);
+          return;
+        }
+      } else if (!first.ok) {
+        console.warn('Open source fetch failed:', first.status, first.statusText);
         return;
       }
 
@@ -799,20 +828,16 @@ const hasSeededMockDataRef = useRef(false);
         done: [],
       };
 
-      (data as OpenSourceEntry[]).forEach((entry: OpenSourceEntry) => {
+      rows.forEach((entry: OpenSourceEntry) => {
         const column = openSourceStatusToColumn[entry.status] ?? 'plan';
         grouped[column].push(entry);
       });
 
-      if (openSourceFetchQuery.type === 'enrollment') {
-        setOpenSourceListScope({
-          mode: 'enrollment',
-          enrollmentId: openSourceFetchQuery.enrollmentId,
-        });
-      } else {
-        setOpenSourceListScope({ mode: 'all', enrollmentId: null });
-      }
-
+      setOpenSourceListScope(
+        scopeMode === 'enrollment' && scopeEnroll != null
+          ? { mode: 'enrollment', enrollmentId: scopeEnroll }
+          : { mode: 'all', enrollmentId: null }
+      );
       setOpenSourceColumns(grouped);
     } catch (error) {
       console.error('Error fetching open source entries:', error);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -50,6 +50,22 @@ function openSourceDateForMonthFilter(entry: OpenSourceEntry): string | null {
   return entry.dateModified ?? entry.dateCreated ?? null;
 }
 
+function groupOpenSourceRowsByStatus(
+  rows: OpenSourceEntry[]
+): Record<OpenSourceColumnId, OpenSourceEntry[]> {
+  const grouped: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+    plan: [],
+    babyStep: [],
+    inProgress: [],
+    done: [],
+  };
+  rows.forEach((entry: OpenSourceEntry) => {
+    const column = openSourceStatusToColumn[entry.status] ?? 'plan';
+    grouped[column].push(entry);
+  });
+  return grouped;
+}
+
 function mapCompletedPartnershipsFromApi(
   completed: { id: number; partnershipId: number; partnershipName: string; criteria: unknown }[]
 ): Array<{ id: number; partnershipId: number; partnershipName: string; criteria: any[] }> {
@@ -708,7 +724,7 @@ const hasSeededMockDataRef = useRef(false);
   const isDraggingOpenSourceRef = useRef(false);
   const [showProofOfWorkWarning, setShowProofOfWorkWarning] = useState(false);
 
-  /** When we have a stable `UserPartnerhip` id + aliases, request only those rows (server filter). */
+  /** When we have a stable `UserPartnership` enrollment id + aliases, request only those rows (server filter; may fall back to full list). */
   const openSourceFetchQuery = useMemo(():
     | { type: 'all' }
     | { type: 'enrollment'; enrollmentId: number; nameAliases: string[] } => {
@@ -793,8 +809,8 @@ const hasSeededMockDataRef = useRef(false);
         }
       }
 
-      const usedScopedUrl = openSourceFetchQuery.type === 'enrollment';
-      const tryFullListFallback = usedScopedUrl && (!first.ok || rows.length === 0);
+      const tryFullListFallback =
+        openSourceFetchQuery.type === 'enrollment' && (!first.ok || rows.length === 0);
       let scopeMode: 'all' | 'enrollment' = 'all';
       let scopeEnroll: number | null = null;
       if (openSourceFetchQuery.type === 'enrollment') {
@@ -821,24 +837,12 @@ const hasSeededMockDataRef = useRef(false);
         return;
       }
 
-      const grouped: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
-        plan: [],
-        babyStep: [],
-        inProgress: [],
-        done: [],
-      };
-
-      rows.forEach((entry: OpenSourceEntry) => {
-        const column = openSourceStatusToColumn[entry.status] ?? 'plan';
-        grouped[column].push(entry);
-      });
-
       setOpenSourceListScope(
         scopeMode === 'enrollment' && scopeEnroll != null
           ? { mode: 'enrollment', enrollmentId: scopeEnroll }
           : { mode: 'all', enrollmentId: null }
       );
-      setOpenSourceColumns(grouped);
+      setOpenSourceColumns(groupOpenSourceRowsByStatus(rows));
     } catch (error) {
       console.error('Error fetching open source entries:', error);
     } finally {
@@ -1619,12 +1623,17 @@ const hasSeededMockDataRef = useRef(false);
       });
     }
 
+    const completedForView = viewingCompletedPartnershipName
+      ? completedPartnerships.find(
+          c =>
+            normalizePartnerName(c.partnershipName) ===
+            normalizePartnerName(viewingCompletedPartnershipName)
+        )
+      : undefined;
+
     let enrollmentFilterId: number | null = null;
     if (viewingCompletedPartnershipName) {
-      const cp = completedPartnerships.find(
-        c => normalizePartnerName(c.partnershipName) === normalizePartnerName(viewingCompletedPartnershipName)
-      );
-      enrollmentFilterId = cp?.id ?? null;
+      enrollmentFilterId = completedForView?.id ?? null;
     } else if (selectedPartnership) {
       enrollmentFilterId = activePartnershipDbId;
     }
@@ -1648,11 +1657,8 @@ const hasSeededMockDataRef = useRef(false);
 
     let nameSet: Set<string> | null = null;
     if (viewingCompletedPartnershipName) {
-      const cp = completedPartnerships.find(
-        c => normalizePartnerName(c.partnershipName) === normalizePartnerName(viewingCompletedPartnershipName)
-      );
       nameSet = buildPartnershipNameMatchSet(
-        cp?.partnershipId ?? null,
+        completedForView?.partnershipId ?? null,
         viewingCompletedPartnershipName,
         availablePartnerships,
         fullPartnerships

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -40,6 +40,73 @@ import {
   APPLICATION_COMPLETION_COLUMNS,
   EVENT_COMPLETION_COLUMNS,
 } from './components/types';
+import partnershipsData from '@/partnerships/partnerships.json';
+
+/** Trims and lowercases for resilient matching when DB/JSON/Partnership.name drift. */
+function normalizePartnerName(s: string | null | undefined): string {
+  return (s ?? '').trim().toLowerCase();
+}
+
+/** All known string forms for a partnership (display name, JSON, API lists) — no DB column changes. */
+function buildPartnershipNameMatchSet(
+  partnershipId: number | null,
+  displayName: string | null,
+  availablePartnerships: Array<{ id: number; name: string }>,
+  fullPartnerships: Array<{ id: number; name: string }>
+): Set<string> {
+  const out = new Set<string>();
+  if (displayName) out.add(normalizePartnerName(displayName));
+  if (partnershipId != null) {
+    const fromJson = partnershipsData.partnerships.find(p => p.id === partnershipId)?.name;
+    if (fromJson) out.add(normalizePartnerName(fromJson));
+    const fromAvail = availablePartnerships.find(p => p.id === partnershipId)?.name;
+    if (fromAvail) out.add(normalizePartnerName(fromAvail));
+    const fromFull = fullPartnerships.find(p => p.id === partnershipId)?.name;
+    if (fromFull) out.add(normalizePartnerName(fromFull));
+  }
+  return out;
+}
+
+function openSourceDateForMonthFilter(entry: OpenSourceEntry): string | null {
+  return entry.dateModified ?? entry.dateCreated ?? null;
+}
+
+function mapCompletedPartnershipsFromApi(
+  completed: { id: number; partnershipId: number; partnershipName: string; criteria: unknown }[]
+) {
+  return (completed || []).map((p) => ({
+    id: p.id,
+    partnershipId: p.partnershipId,
+    partnershipName: p.partnershipName,
+    criteria: p.criteria || [],
+  }));
+}
+
+function withAugmentNameSetForActiveSingleDistinct(
+  nameSet: Set<string>,
+  timeFiltered: Record<OpenSourceColumnId, OpenSourceEntry[]>
+): Set<string> {
+  const out = new Set(nameSet);
+  const flat = Object.values(timeFiltered).flat() as OpenSourceEntry[];
+  const distinct = [
+    ...new Set(flat.map(e => normalizePartnerName(e.partnershipName)).filter(n => n !== '')),
+  ];
+  if (distinct.length === 1) {
+    out.add(distinct[0]!);
+  }
+  return out;
+}
+
+function openSourceEntryMatchesNameSet(
+  entry: OpenSourceEntry,
+  nameSet: Set<string> | null,
+  isActiveView: boolean
+): boolean {
+  if (!nameSet || nameSet.size === 0) return true;
+  const n = normalizePartnerName(entry.partnershipName);
+  if (n === '') return isActiveView;
+  return nameSet.has(n);
+}
 
 // ===== MOCK DATA FEATURE TOGGLE START =====
 // Toggle this flag or comment out the seeding effect below to disable mock data.
@@ -622,10 +689,12 @@ const hasSeededMockDataRef = useRef(false);
   const [isLoadingOpenSource, setIsLoadingOpenSource] = useState(true);
   const [openSourceFilter, setOpenSourceFilter] = useState<BoardTimeFilter>('allTime');
   const [selectedPartnership, setSelectedPartnership] = useState<string | null>(null);
-  const [, setSelectedPartnershipId] = useState<number | null>(null);
+  const [selectedPartnershipId, setSelectedPartnershipId] = useState<number | null>(null);
   const [activePartnershipDbId, setActivePartnershipDbId] = useState<number | null>(null);
   const [activePartnershipCriteria, setActivePartnershipCriteria] = useState<any[]>([]);
-  const [completedPartnerships, setCompletedPartnerships] = useState<Array<{ id: number; partnershipName: string; criteria: any[] }>>([]);
+  const [completedPartnerships, setCompletedPartnerships] = useState<
+    Array<{ id: number; partnershipId: number; partnershipName: string; criteria: any[] }>
+  >([]);
   const [viewingCompletedPartnershipName, setViewingCompletedPartnershipName] = useState<string | null>(null);
   const [availablePartnerships, setAvailablePartnerships] = useState<Array<{ id: number; name: string; spotsRemaining: number }>>([]);
   const [fullPartnerships, setFullPartnerships] = useState<Array<{ id: number; name: string }>>([]);
@@ -647,18 +716,15 @@ const hasSeededMockDataRef = useRef(false);
         const url = userIdParam ? `/api/open_source?userId=${userIdParam}` : '/api/open_source';
       const response = await fetch(url);
       if (!response.ok) {
-        // If endpoint doesn't exist yet, just set empty columns
-        setOpenSourceColumns({
-          plan: [],
-          babyStep: [],
-          inProgress: [],
-          done: [],
-        });
-        setIsLoadingOpenSource(false);
-        isFetchingOpenSourceRef.current = false;
+        // Do not wipe the board on transient 401/503 (e.g. session not ready) — that hid real DB rows in prod.
+        console.warn('Open source fetch failed:', response.status, response.statusText);
         return;
       }
-      const data = await response.json() as OpenSourceEntry[];
+      const data = await response.json();
+      if (!Array.isArray(data)) {
+        console.error('Open source: expected array', data);
+        return;
+      }
 
       const grouped: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
         plan: [],
@@ -667,7 +733,7 @@ const hasSeededMockDataRef = useRef(false);
         done: [],
       };
 
-      data.forEach((entry: OpenSourceEntry) => {
+      (data as OpenSourceEntry[]).forEach((entry: OpenSourceEntry) => {
         const column = openSourceStatusToColumn[entry.status] ?? 'plan';
         grouped[column].push(entry);
       });
@@ -675,13 +741,6 @@ const hasSeededMockDataRef = useRef(false);
       setOpenSourceColumns(grouped);
     } catch (error) {
       console.error('Error fetching open source entries:', error);
-      // On error, set empty columns
-      setOpenSourceColumns({
-        plan: [],
-        babyStep: [],
-        inProgress: [],
-        done: [],
-      });
     } finally {
       setIsLoadingOpenSource(false);
       isFetchingOpenSourceRef.current = false;
@@ -711,17 +770,17 @@ const hasSeededMockDataRef = useRef(false);
         setSelectedPartnershipId(null);
         setActivePartnershipDbId(null);
         setCompletedPartnerships([]);
+        setViewingCompletedPartnershipName(null);
         return;
       }
       const data = await response.json();
-      const completed = (data.completed || []).map((p: { id: number; partnershipName: string; criteria: any[] }) => ({ id: p.id, partnershipName: p.partnershipName, criteria: p.criteria || [] }));
-      setCompletedPartnerships(completed);
+      setCompletedPartnerships(mapCompletedPartnershipsFromApi(data.completed || []));
       if (data.active) {
         setSelectedPartnership(data.active.partnershipName);
         setSelectedPartnershipId(data.active.partnershipId);
         setActivePartnershipDbId(data.active.id);
         setActivePartnershipCriteria(data.active.criteria || []);
-        setViewingCompletedPartnershipName(null); // Clear completed view when active exists
+        // Do not clear completed-view here: refetch runs often and would undo a click on history.
       } else if (completed.length > 0) {
         // No active partnership, but there are completed ones - show the most recent completed
         const mostRecent = completed[0]; // Already sorted by completedAt desc from API
@@ -751,8 +810,7 @@ const hasSeededMockDataRef = useRef(false);
       const response = await fetch(url);
       if (!response.ok) return;
       const data = await response.json();
-      const completed = (data.completed || []).map((p: { id: number; partnershipName: string; criteria: any[] }) => ({ id: p.id, partnershipName: p.partnershipName, criteria: p.criteria || [] }));
-      setCompletedPartnerships(completed);
+      setCompletedPartnerships(mapCompletedPartnershipsFromApi(data.completed || []));
     } catch (error) {
       console.error('Error refreshing completed partnerships:', error);
     }
@@ -1438,24 +1496,89 @@ const hasSeededMockDataRef = useRef(false);
     [metricsMonth, metricsMonthEnd]
   );
 
+  /** Time filter, partnership name set (incl. single-name drift), and view mode — shared by board and criteria. */
+  const openSourceNameFilterState = useMemo(() => {
+    const effectiveTimeFilter: BoardTimeFilter = viewingCompletedPartnershipName ? 'allTime' : openSourceFilter;
+
+    let timeFiltered: Record<OpenSourceColumnId, OpenSourceEntry[]>;
+    if (effectiveTimeFilter === 'allTime') {
+      timeFiltered = { ...openSourceColumns };
+    } else {
+      timeFiltered = {
+        plan: [],
+        babyStep: [],
+        inProgress: [],
+        done: [],
+      };
+      (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
+        if (effectiveTimeFilter === 'modifiedThisMonth') {
+          timeFiltered[columnId] = openSourceColumns[columnId].filter(entry =>
+            isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
+          );
+        }
+      });
+    }
+
+    let nameSet: Set<string> | null = null;
+    if (viewingCompletedPartnershipName) {
+      const cp = completedPartnerships.find(
+        c => normalizePartnerName(c.partnershipName) === normalizePartnerName(viewingCompletedPartnershipName)
+      );
+      nameSet = buildPartnershipNameMatchSet(
+        cp?.partnershipId ?? null,
+        viewingCompletedPartnershipName,
+        availablePartnerships,
+        fullPartnerships
+      );
+    } else if (selectedPartnership) {
+      nameSet = buildPartnershipNameMatchSet(
+        selectedPartnershipId,
+        selectedPartnership,
+        availablePartnerships,
+        fullPartnerships
+      );
+    }
+
+    if (nameSet && nameSet.size > 0 && selectedPartnership && !viewingCompletedPartnershipName) {
+      nameSet = withAugmentNameSetForActiveSingleDistinct(nameSet, timeFiltered);
+    }
+
+    const isActiveView = Boolean(selectedPartnership && !viewingCompletedPartnershipName);
+
+    return { timeFiltered, nameSet, isActiveView };
+  }, [
+    openSourceColumns,
+    openSourceFilter,
+    viewingCompletedPartnershipName,
+    completedPartnerships,
+    selectedPartnership,
+    selectedPartnershipId,
+    availablePartnerships,
+    fullPartnerships,
+    isWithinCurrentMonth,
+  ]);
 
   const openSourceCriteria = useMemo(() => {
     const doneEntries = openSourceColumns.done ?? [];
+    const { nameSet, isActiveView } = openSourceNameFilterState;
     const totalCriteria = activePartnershipCriteria.reduce((sum, criteria) => {
       const count = Number(criteria?.count);
       return sum + (Number.isFinite(count) && count > 0 ? count : 1);
     }, 0);
-    const activePartnershipDoneCount = selectedPartnership
-      ? doneEntries.filter((entry) => entry.partnershipName === selectedPartnership).reduce((sum, entry) => {
-          const extras = Array.isArray(entry.selectedExtras) ? entry.selectedExtras.length : 0;
-          return sum + 1 + extras;
-        }, 0)
-      : 0;
+    const activePartnershipDoneCount =
+      nameSet && nameSet.size > 0
+        ? doneEntries
+            .filter(entry => openSourceEntryMatchesNameSet(entry, nameSet, isActiveView))
+            .reduce((sum, entry) => {
+              const extras = Array.isArray(entry.selectedExtras) ? entry.selectedExtras.length : 0;
+              return sum + 1 + extras;
+            }, 0)
+        : 0;
     const completedCriteria =
       totalCriteria > 0 ? Math.min(activePartnershipDoneCount, totalCriteria) : activePartnershipDoneCount;
 
     return { completedCriteria, totalCriteria };
-  }, [openSourceColumns, selectedPartnership, activePartnershipCriteria]);
+  }, [openSourceColumns, openSourceNameFilterState, activePartnershipCriteria]);
 
   const filteredAppColumns = useMemo(() => {
     if (applicationsFilter === 'allTime') return appColumns;
@@ -1513,38 +1636,38 @@ const hasSeededMockDataRef = useRef(false);
   }, [eventColumns, eventsFilter, isWithinCurrentMonth]);
 
   const filteredOpenSourceColumns = useMemo(() => {
-    let filtered: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
-      plan: [],
-      babyStep: [],
-      inProgress: [],
-      done: [],
+    const { timeFiltered, nameSet, isActiveView } = openSourceNameFilterState;
+    const filtered: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+      plan: [...timeFiltered.plan],
+      babyStep: [...timeFiltered.babyStep],
+      inProgress: [...timeFiltered.inProgress],
+      done: [...timeFiltered.done],
     };
 
-    // First apply time filter
-    if (openSourceFilter === 'allTime') {
-      filtered = { ...openSourceColumns };
-    } else {
-      (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
-        if (openSourceFilter === 'modifiedThisMonth') {
-          filtered[columnId] = openSourceColumns[columnId].filter(entry =>
-            isWithinCurrentMonth(entry.dateModified)
-          );
-        }
-      });
-    }
-
-    // Then apply partnership filter - use viewing completed partnership if set, else current
-    const partnershipFilter = viewingCompletedPartnershipName ?? selectedPartnership;
-    if (partnershipFilter) {
+    if (nameSet && nameSet.size > 0) {
       (Object.keys(filtered) as OpenSourceColumnId[]).forEach(columnId => {
         filtered[columnId] = filtered[columnId].filter(entry =>
-          entry.partnershipName === partnershipFilter
+          openSourceEntryMatchesNameSet(entry, nameSet, isActiveView)
         );
       });
     }
 
+    if (selectedPartnership && !viewingCompletedPartnershipName) {
+      const total = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
+        (acc, k) => acc + filtered[k as OpenSourceColumnId].length,
+        0
+      );
+      const timeTotal = (Object.keys(timeFiltered) as OpenSourceColumnId[]).reduce(
+        (acc, k) => acc + timeFiltered[k as OpenSourceColumnId].length,
+        0
+      );
+      if (total === 0 && timeTotal > 0) {
+        return timeFiltered;
+      }
+    }
+
     return filtered;
-  }, [openSourceColumns, openSourceFilter, selectedPartnership, viewingCompletedPartnershipName, isWithinCurrentMonth]);
+  }, [openSourceNameFilterState, selectedPartnership, viewingCompletedPartnershipName]);
 
   const handleTabClick = (tabId: string) => {
     setActiveTab(tabId);

--- a/app/lib/partnership-aliases.ts
+++ b/app/lib/partnership-aliases.ts
@@ -1,0 +1,39 @@
+import partnershipsData from '@/partnerships/partnerships.json';
+import { normalizePartnerName } from '@/app/lib/partnership-name';
+
+/** Un-trimmed, unique name strings to match on DB `partnershipName` and for API query params. */
+export function getPartnershipNameAliasStrings(
+  partnershipId: number | null,
+  displayName: string | null,
+  availablePartnerships: Array<{ id: number; name: string }>,
+  fullPartnerships: Array<{ id: number; name: string }>
+): string[] {
+  const raw: string[] = [];
+  if (displayName) raw.push(displayName);
+  if (partnershipId != null) {
+    const fromJson = partnershipsData.partnerships.find(p => p.id === partnershipId)?.name;
+    if (fromJson) raw.push(fromJson);
+    const fromAvail = availablePartnerships.find(p => p.id === partnershipId)?.name;
+    if (fromAvail) raw.push(fromAvail);
+    const fromFull = fullPartnerships.find(p => p.id === partnershipId)?.name;
+    if (fromFull) raw.push(fromFull);
+  }
+  return [...new Set(raw.map(s => s.trim()).filter(Boolean))];
+}
+
+/** Normalized set for client-side / resilient matching. */
+export function buildPartnershipNameMatchSet(
+  partnershipId: number | null,
+  displayName: string | null,
+  availablePartnerships: Array<{ id: number; name: string }>,
+  fullPartnerships: Array<{ id: number; name: string }>
+): Set<string> {
+  return new Set(
+    getPartnershipNameAliasStrings(
+      partnershipId,
+      displayName,
+      availablePartnerships,
+      fullPartnerships
+    ).map(s => normalizePartnerName(s))
+  );
+}

--- a/app/lib/partnership-name.ts
+++ b/app/lib/partnership-name.ts
@@ -1,0 +1,4 @@
+/** Trims and lowercases for matching when names drift between DB, JSON, and API lists. */
+export function normalizePartnerName(s: string | null | undefined): string {
+  return (s ?? '').trim().toLowerCase();
+}

--- a/auth.ts
+++ b/auth.ts
@@ -11,7 +11,14 @@ export const { handlers: { GET, POST }, auth, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(prisma),
   session: { strategy: "jwt" },
   ...authConfig,
-  callbacks: { 
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user?.id) {
+        (token as { prismaUserId?: string }).prismaUserId = user.id;
+      }
+      return token;
+    },
+
     async redirect({ url, baseUrl }) {
       // Handle relative paths - allow them to pass through
       if (url.startsWith("/")) {
@@ -26,11 +33,20 @@ export const { handlers: { GET, POST }, auth, signIn, signOut } = NextAuth({
       return baseUrl
     },
    
-    async session({ session, user }) {
-      // Fetch the user from the database to include all fields
-      const dbUser = await prisma.user.findUnique({
-        where: { email: session.user.email },
-      })
+    async session({ session, token }) {
+      const email =
+        (typeof session.user?.email === "string" && session.user.email) ||
+        (typeof token.email === "string" && token.email) ||
+        undefined;
+
+      let dbUser = email
+        ? await prisma.user.findUnique({ where: { email } })
+        : null;
+
+      const prismaUserId = (token as { prismaUserId?: string }).prismaUserId;
+      if (!dbUser && prismaUserId) {
+        dbUser = await prisma.user.findUnique({ where: { id: prismaUserId } });
+      }
 
       if (dbUser) {
         session.user = {
@@ -46,10 +62,10 @@ export const { handlers: { GET, POST }, auth, signIn, signOut } = NextAuth({
           inPersonEventsPerMonth: dbUser.inPersonEventsPerMonth,
           careerFairsPerYear: dbUser.careerFairsPerYear,
           resetStartDate: dbUser.resetStartDate,
-        } as typeof session.user
+        } as typeof session.user;
       }
 
-      return session
+      return session;
     },
   }
 })

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "private": true,
   "scripts": {
     "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:db:push": "prisma db push --accept-data-loss",
     "prisma:seed": "prisma db seed",
     "prisma:generate:nvm": "PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH prisma generate",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,34 +113,40 @@ model Partnership {
 }
 
 model UserPartnership {
-  id              Int         @id @default(autoincrement())
-  userId          String
-  partnershipId   Int
-  status          String      @default("active")  // "active", "completed", "abandoned"
-  selections      Json?       // Store multiple choice selections: { "0": "high_quality_question" }
-  startedAt       DateTime    @default(now())
-  completedAt     DateTime?
-  user            User        @relation(fields: [userId], references: [id])
-  partnership     Partnership @relation(fields: [partnershipId], references: [id])
+  id                Int                @id @default(autoincrement())
+  userId            String
+  partnershipId     Int
+  status            String             @default("active") // "active", "completed", "abandoned"
+  selections        Json?              // Store multiple choice selections: { "0": "high_quality_question" }
+  startedAt         DateTime           @default(now())
+  completedAt       DateTime?
+  user              User               @relation(fields: [userId], references: [id])
+  partnership       Partnership        @relation(fields: [partnershipId], references: [id])
+  openSourceEntries OpenSourceEntry[]
 }
 
 model OpenSourceEntry {
-  id                Int       @id @default(autoincrement())
+  id                Int              @id @default(autoincrement())
   partnershipName   String
-  criteriaType      String?   // e.g., "issue", "blog_post", "multiple_choice"
+  userPartnershipId Int?
+  criteriaType      String?          // e.g., "issue", "blog_post", "multiple_choice"
   metric            String?
-  status          String    @default("plan")
-  selectedExtras  Json?     // Array of criteria types: ["receive_feedback", "closer"]
-  planFields      Json?     // Definition: [{ type: "URL", text: "Link..." }]
-  planResponses   Json?     // Answers for plan phase
-  babyStepFields  Json?     // Definition: [{ type: "URL", text: "Find..." }]
-  babyStepResponses Json?   // Answers for baby step phase
-  proofOfCompletion Json?     // Definition: [{ type: "URL", text: "Link..." }]
-  proofResponses    Json?     // Answers for completion phase
-  dateCreated     DateTime  @default(now())
-  dateModified    DateTime?
-  userId          String
-  user            User      @relation(fields: [userId], references: [id])
+  status            String           @default("plan")
+  selectedExtras    Json?            // Array of criteria types: ["receive_feedback", "closer"]
+  planFields        Json?            // Definition: [{ type: "URL", text: "Link..." }]
+  planResponses     Json?            // Answers for plan phase
+  babyStepFields    Json?            // Definition: [{ type: "URL", text: "Find..." }]
+  babyStepResponses Json?            // Answers for baby step phase
+  proofOfCompletion Json?            // Definition: [{ type: "URL", text: "Link..." }]
+  proofResponses    Json?            // Answers for completion phase
+  dateCreated       DateTime         @default(now())
+  dateModified      DateTime?
+  userId            String
+  user              User             @relation(fields: [userId], references: [id])
+  userPartnership   UserPartnership? @relation(fields: [userPartnershipId], references: [id], onDelete: Restrict)
+
+  @@index([userId, userPartnershipId])
+  @@index([userPartnershipId])
 }
 
 model VerificationToken {


### PR DESCRIPTION
## Note
 Since this was **_urgent_**, I asked cursor to give me the explanation and immediately pasted it below. But what's important is that I tested on my staged [vercel site](https://offer-insight-swart.vercel.app/instructor/signin) and it shows up now, the cards.

---

## Summary

This PR delivers two related improvements to how open-source board cards are stored, deleted, and loaded—especially for users with both an **active** and **completed** program history.

---

### 1. Link cards to a specific enrollment (`userPartnershipId`)

- **Schema:** `OpenSourceEntry` now has an optional `userPartnershipId` FK(foreign key) to `UserPartnership`, with indexes and `onDelete: Restrict` so we don’t accidentally cascade in ways we don’t mean.
- **Data:** A migration backfills old rows by matching `partnershipName` and time windows where possible, then fills the rest in the usual “active / completed” paths over time.
- **Writes:** New cards created when a partnership is started (and via `POST` open source when the active program matches) set this id so each row is tied to the right **UserPartnership** row, not only a free-text name.
- **Instructor tools:** `deleteMany` no longer wipes every open-source row for the user. It only removes rows for the **current active enrollment** when switching or abandoning, so work tied to **completed** programs is not deleted as a side effect.
- **Dashboard:** Filtering prefers `userPartnership` on the card when we know the enrollment (active or a selected completed row); legacy rows without a FK still use the existing name/alias + augment + time-window behavior.

**Why it matters:** Completed programs stay visible in history, and their cards are no longer wiped by instructor “switch / abandon” flows that were previously deleting **all** open-source entries for that user.

---

### 2. Smaller list payloads (optional) + full-list fallback

- **API:** `GET /api/open_source` can take `?enrollment=<id>` and repeated `&name=...` so the server can return only rows for that enrollment (FK and/or legacy name matches) when the client has a stable id and name aliases.
- **Client:** When that scoped request **fails or returns an empty list** (e.g. env drift, legacy names, or first load before data lines up), the app **falls back to the unfiltered list** and keeps using the **existing** client-side program + time filters so the board still populates (this was important for Vercel).
- **Scope state:** We track whether the last successful load was scoped to an enrollment or the full list, and **skip** redundant on-screen program filtering when the server already returned only the right program.

**Why it matters:** You get a lighter response when the scoped path works, without breaking prod when the scoped path returns nothing—the UI self-heals by refetching the full list and filtering in the app.

---

### Code cleanups, typescript fixes

- Small comment / typing cleanups (e.g. `mapCompletedPartnerhips` criteria typing for `tsc` on build).
- Shared helpers for normalizing and resolving partnership **name** aliases (`partnership-name` / `partnership-aliases`).

## Test plan

- [ ] Local: create/join a partnership, confirm new cards have `userPartnerhipId` set; switch/abandon as instructor and confirm only current program cards are removed, completed program cards remain.
- [ ] Dashboard: open source tab with active and completed program; time filters and “view completed” still look correct.
- [ ] Vercel/preview: open source cards appear; Network tab may show scoped `open_source` then a fallback to full list when needed.
- [ ] `pnpm build` passes.