### PR TITLE
View active cards fix

### DIFF
--- a/app/api/open_source/route.ts
+++ b/app/api/open_source/route.ts
@@ -14,6 +14,24 @@ export async function GET(request: NextRequest) {
     const entries = await prisma.openSourceEntry.findMany({
       where: { userId },
       orderBy: { dateCreated: 'desc' },
+      // Explicit select keeps this route compatible with DBs that don't yet have newer optional columns.
+      select: {
+        id: true,
+        partnershipName: true,
+        criteriaType: true,
+        metric: true,
+        status: true,
+        selectedExtras: true,
+        planFields: true,
+        planResponses: true,
+        babyStepFields: true,
+        babyStepResponses: true,
+        proofOfCompletion: true,
+        proofResponses: true,
+        dateCreated: true,
+        dateModified: true,
+        userId: true,
+      },
     });
 
     return NextResponse.json(entries);

--- a/app/api/users/partnership/route.ts
+++ b/app/api/users/partnership/route.ts
@@ -5,6 +5,32 @@ import { getInstructorSession } from "@/app/lib/instructor-auth";
 import partnershipsData from "@/partnerships/partnerships.json";
 import typesData from "@/partnerships/types.json";
 
+function normalizeName(s: string | null | undefined): string {
+  return (s ?? "").trim().toLowerCase();
+}
+
+/** Build all known partnership name aliases (DB + JSON) for safer matching. */
+function buildPartnershipAliases(partnershipId: number, dbName?: string | null): string[] {
+  const out = new Map<string, string>();
+  const add = (value?: string | null) => {
+    const raw = (value ?? "").trim();
+    if (!raw) return;
+    const n = normalizeName(raw);
+    if (!out.has(n)) out.set(n, raw);
+  };
+
+  add(dbName);
+  const fromJson = partnershipsData.partnerships.find(p => p.id === partnershipId)?.name;
+  add(fromJson);
+  return [...out.values()];
+}
+
+function partnershipNameOrWhere(aliasNames: string[]) {
+  return aliasNames.map((name) => ({
+    partnershipName: { equals: name, mode: "insensitive" as const },
+  }));
+}
+
 // Builds the full criteria array for a given partnership + user multiple-choice selections.
 function buildCriteria(partnershipId: number, selections: Record<string, string>) {
   let mcIndex = 0;
@@ -189,13 +215,63 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // If instructor is switching partnerships, abandon the old one and delete all cards
+    // If instructor is switching partnerships, abandon the old one and delete only that partnership's cards
     // This happens BEFORE creating the new one to ensure proper count tracking
     if (existingActive && isInstructor) {
-      // Delete all open source entries for this user
-      await prisma.openSourceEntry.deleteMany({
-        where: { userId },
+      const activeAliases = buildPartnershipAliases(
+        existingActive.partnershipId,
+        existingActive.partnership?.name
+      );
+      const completedRows = await prisma.userPartnership.findMany({
+        where: { userId, status: "completed" },
+        include: { partnership: true },
       });
+      const protectedAliases = new Set(
+        completedRows
+          .flatMap((row) =>
+            buildPartnershipAliases(row.partnershipId, row.partnership?.name)
+          )
+          .map((n) => normalizeName(n))
+      );
+      const overlap = activeAliases.filter((n) =>
+        protectedAliases.has(normalizeName(n))
+      );
+      if (overlap.length > 0) {
+        // Safer to skip deletion than risk removing historical completed cards.
+        console.warn(
+          "[Partnership] Switch delete skipped due to active/completed alias overlap",
+          { userId, activePartnershipId: existingActive.partnershipId, overlap }
+        );
+      } else {
+        const activeOr = partnershipNameOrWhere(activeAliases);
+        const [targetCount, totalUserCount] = await Promise.all([
+          prisma.openSourceEntry.count({ where: { userId, OR: activeOr } }),
+          prisma.openSourceEntry.count({ where: { userId } }),
+        ]);
+        if (targetCount > totalUserCount) {
+          console.warn("[Partnership] Switch delete aborted due to invalid counts", {
+            userId,
+            targetCount,
+            totalUserCount,
+            activePartnershipId: existingActive.partnershipId,
+          });
+        } else {
+          if (targetCount === 0) {
+            console.info("[Partnership] Switch delete matched no cards", {
+              userId,
+              activePartnershipId: existingActive.partnershipId,
+              activeAliases,
+            });
+          }
+          // Keep completed-history cards from other partnerships intact
+          await prisma.openSourceEntry.deleteMany({
+            where: {
+              userId,
+              OR: activeOr,
+            },
+          });
+        }
+      }
 
       // Abandon the old partnership (only if switching to a different one)
       if (existingActive.partnershipId !== partnershipId) {
@@ -453,6 +529,9 @@ export async function DELETE(request: NextRequest) {
         userId,
         status: "active",
       },
+      include: {
+        partnership: true,
+      },
     });
 
     if (!activePartnership) {
@@ -462,12 +541,61 @@ export async function DELETE(request: NextRequest) {
       );
     }
 
-    // Delete all cards and abandon partnership
+    // Delete only active partnership cards and abandon partnership
     await prisma.$transaction(async (tx) => {
-      // Delete all open source entries for this user
-      await tx.openSourceEntry.deleteMany({
-        where: { userId },
+      const activeAliases = buildPartnershipAliases(
+        activePartnership.partnershipId,
+        activePartnership.partnership?.name
+      );
+      const completedRows = await tx.userPartnership.findMany({
+        where: { userId, status: "completed" },
+        include: { partnership: true },
       });
+      const protectedAliases = new Set(
+        completedRows
+          .flatMap((row) =>
+            buildPartnershipAliases(row.partnershipId, row.partnership?.name)
+          )
+          .map((n) => normalizeName(n))
+      );
+      const overlap = activeAliases.filter((n) =>
+        protectedAliases.has(normalizeName(n))
+      );
+      if (overlap.length > 0) {
+        console.warn(
+          "[Partnership] Abandon delete skipped due to active/completed alias overlap",
+          { userId, activePartnershipId: activePartnership.partnershipId, overlap }
+        );
+      } else {
+        const activeOr = partnershipNameOrWhere(activeAliases);
+        const [targetCount, totalUserCount] = await Promise.all([
+          tx.openSourceEntry.count({ where: { userId, OR: activeOr } }),
+          tx.openSourceEntry.count({ where: { userId } }),
+        ]);
+        if (targetCount > totalUserCount) {
+          console.warn("[Partnership] Abandon delete aborted due to invalid counts", {
+            userId,
+            targetCount,
+            totalUserCount,
+            activePartnershipId: activePartnership.partnershipId,
+          });
+        } else {
+          if (targetCount === 0) {
+            console.info("[Partnership] Abandon delete matched no cards", {
+              userId,
+              activePartnershipId: activePartnership.partnershipId,
+              activeAliases,
+            });
+          }
+          // Keep cards from completed/other partnerships
+          await tx.openSourceEntry.deleteMany({
+            where: {
+              userId,
+              OR: activeOr,
+            },
+          });
+        }
+      }
 
       // Abandon the partnership
       await tx.userPartnership.update({

--- a/app/dashboard/components/OpenSourceTab.tsx
+++ b/app/dashboard/components/OpenSourceTab.tsx
@@ -44,7 +44,14 @@ type OpenSourceTabProps = {
   fullPartnerships: Array<{ id: number; name: string; criteria?: any[] }>;
   fetchAvailablePartnerships: () => Promise<void>;
   refreshCompletedPartnerships?: () => Promise<void>;
-  completedPartnerships?: Array<{ id: number; partnershipName: string; criteria: any[] }>;
+  completedPartnerships?: Array<{
+    id: number;
+    partnershipId?: number;
+    partnershipName: string;
+    criteria: any[];
+    startedAt?: string | null;
+    completedAt?: string | null;
+  }>;
   viewingCompletedPartnershipName?: string | null;
   setViewingCompletedPartnershipName?: (name: string | null) => void;
   isInstructor?: boolean;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1726,31 +1726,33 @@ const hasSeededMockDataRef = useRef(false);
       }
     }
 
-    const finalTotal = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
-      (acc, k) => acc + filtered[k as OpenSourceColumnId].length,
-      0
-    );
-    if (finalTotal === 0) {
-      const base: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
-        plan: [],
-        babyStep: [],
-        inProgress: [],
-        done: [],
-      };
-      (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
-        base[columnId] =
-          effectiveTimeFilter === 'allTime'
-            ? [...openSourceColumns[columnId]]
-            : openSourceColumns[columnId].filter(entry =>
-                isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
-              );
-      });
-      const baseTotal = (Object.keys(base) as OpenSourceColumnId[]).reduce(
-        (acc, k) => acc + base[k as OpenSourceColumnId].length,
+    if (!viewingCompletedPartnershipName) {
+      const finalTotal = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
+        (acc, k) => acc + filtered[k as OpenSourceColumnId].length,
         0
       );
-      if (baseTotal > 0) {
-        return base;
+      if (finalTotal === 0) {
+        const base: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+          plan: [],
+          babyStep: [],
+          inProgress: [],
+          done: [],
+        };
+        (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
+          base[columnId] =
+            effectiveTimeFilter === 'allTime'
+              ? [...openSourceColumns[columnId]]
+              : openSourceColumns[columnId].filter(entry =>
+                  isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
+                );
+        });
+        const baseTotal = (Object.keys(base) as OpenSourceColumnId[]).reduce(
+          (acc, k) => acc + base[k as OpenSourceColumnId].length,
+          0
+        );
+        if (baseTotal > 0) {
+          return base;
+        }
       }
     }
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -40,6 +40,45 @@ import {
   APPLICATION_COMPLETION_COLUMNS,
   EVENT_COMPLETION_COLUMNS,
 } from './components/types';
+import partnershipsData from '@/partnerships/partnerships.json';
+
+function normalizePartnerName(s: string | null | undefined): string {
+  return (s ?? '').trim().toLowerCase();
+}
+
+function buildPartnershipNameMatchSet(
+  partnershipId: number | null,
+  displayName: string | null,
+  availablePartnerships: Array<{ id: number; name: string }>,
+  fullPartnerships: Array<{ id: number; name: string }>
+): Set<string> {
+  const out = new Set<string>();
+  if (displayName) out.add(normalizePartnerName(displayName));
+  if (partnershipId != null) {
+    const fromJson = partnershipsData.partnerships.find(p => p.id === partnershipId)?.name;
+    if (fromJson) out.add(normalizePartnerName(fromJson));
+    const fromAvail = availablePartnerships.find(p => p.id === partnershipId)?.name;
+    if (fromAvail) out.add(normalizePartnerName(fromAvail));
+    const fromFull = fullPartnerships.find(p => p.id === partnershipId)?.name;
+    if (fromFull) out.add(normalizePartnerName(fromFull));
+  }
+  return out;
+}
+
+function openSourceDateForMonthFilter(entry: OpenSourceEntry): string | null {
+  return entry.dateModified ?? entry.dateCreated ?? null;
+}
+
+function parseIsoDate(value?: string | null): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d;
+}
+
+function entryDateForCompletedWindow(entry: OpenSourceEntry): Date | null {
+  return parseIsoDate(entry.dateCreated ?? entry.dateModified ?? null);
+}
 
 // ===== MOCK DATA FEATURE TOGGLE START =====
 // Toggle this flag or comment out the seeding effect below to disable mock data.
@@ -622,10 +661,19 @@ const hasSeededMockDataRef = useRef(false);
   const [isLoadingOpenSource, setIsLoadingOpenSource] = useState(true);
   const [openSourceFilter, setOpenSourceFilter] = useState<BoardTimeFilter>('allTime');
   const [selectedPartnership, setSelectedPartnership] = useState<string | null>(null);
-  const [, setSelectedPartnershipId] = useState<number | null>(null);
+  const [selectedPartnershipId, setSelectedPartnershipId] = useState<number | null>(null);
   const [activePartnershipDbId, setActivePartnershipDbId] = useState<number | null>(null);
   const [activePartnershipCriteria, setActivePartnershipCriteria] = useState<any[]>([]);
-  const [completedPartnerships, setCompletedPartnerships] = useState<Array<{ id: number; partnershipName: string; criteria: any[] }>>([]);
+  const [completedPartnerships, setCompletedPartnerships] = useState<
+    Array<{
+      id: number;
+      partnershipId: number;
+      partnershipName: string;
+      criteria: any[];
+      startedAt?: string | null;
+      completedAt?: string | null;
+    }>
+  >([]);
   const [viewingCompletedPartnershipName, setViewingCompletedPartnershipName] = useState<string | null>(null);
   const [availablePartnerships, setAvailablePartnerships] = useState<Array<{ id: number; name: string; spotsRemaining: number }>>([]);
   const [fullPartnerships, setFullPartnerships] = useState<Array<{ id: number; name: string }>>([]);
@@ -647,18 +695,15 @@ const hasSeededMockDataRef = useRef(false);
         const url = userIdParam ? `/api/open_source?userId=${userIdParam}` : '/api/open_source';
       const response = await fetch(url);
       if (!response.ok) {
-        // If endpoint doesn't exist yet, just set empty columns
-        setOpenSourceColumns({
-          plan: [],
-          babyStep: [],
-          inProgress: [],
-          done: [],
-        });
-        setIsLoadingOpenSource(false);
-        isFetchingOpenSourceRef.current = false;
+        // Do not wipe the board on transient 401/503/session races.
+        console.warn('Open source fetch failed:', response.status, response.statusText);
         return;
       }
-      const data = await response.json() as OpenSourceEntry[];
+      const data = await response.json();
+      if (!Array.isArray(data)) {
+        console.error('Open source: expected array', data);
+        return;
+      }
 
       const grouped: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
         plan: [],
@@ -667,7 +712,7 @@ const hasSeededMockDataRef = useRef(false);
         done: [],
       };
 
-      data.forEach((entry: OpenSourceEntry) => {
+      (data as OpenSourceEntry[]).forEach((entry: OpenSourceEntry) => {
         const column = openSourceStatusToColumn[entry.status] ?? 'plan';
         grouped[column].push(entry);
       });
@@ -675,13 +720,6 @@ const hasSeededMockDataRef = useRef(false);
       setOpenSourceColumns(grouped);
     } catch (error) {
       console.error('Error fetching open source entries:', error);
-      // On error, set empty columns
-      setOpenSourceColumns({
-        plan: [],
-        babyStep: [],
-        inProgress: [],
-        done: [],
-      });
     } finally {
       setIsLoadingOpenSource(false);
       isFetchingOpenSourceRef.current = false;
@@ -714,14 +752,30 @@ const hasSeededMockDataRef = useRef(false);
         return;
       }
       const data = await response.json();
-      const completed = (data.completed || []).map((p: { id: number; partnershipName: string; criteria: any[] }) => ({ id: p.id, partnershipName: p.partnershipName, criteria: p.criteria || [] }));
+      const completed = (data.completed || []).map(
+        (p: {
+          id: number;
+          partnershipId: number;
+          partnershipName: string;
+          criteria: any[];
+          startedAt?: string | null;
+          completedAt?: string | null;
+        }) => ({
+          id: p.id,
+          partnershipId: p.partnershipId,
+          partnershipName: p.partnershipName,
+          criteria: p.criteria || [],
+          startedAt: p.startedAt ?? null,
+          completedAt: p.completedAt ?? null,
+        })
+      );
       setCompletedPartnerships(completed);
       if (data.active) {
         setSelectedPartnership(data.active.partnershipName);
         setSelectedPartnershipId(data.active.partnershipId);
         setActivePartnershipDbId(data.active.id);
         setActivePartnershipCriteria(data.active.criteria || []);
-        setViewingCompletedPartnershipName(null); // Clear completed view when active exists
+        // Keep completed-view selection; refetch can run after user clicks completed history.
       } else if (completed.length > 0) {
         // No active partnership, but there are completed ones - show the most recent completed
         const mostRecent = completed[0]; // Already sorted by completedAt desc from API
@@ -751,7 +805,23 @@ const hasSeededMockDataRef = useRef(false);
       const response = await fetch(url);
       if (!response.ok) return;
       const data = await response.json();
-      const completed = (data.completed || []).map((p: { id: number; partnershipName: string; criteria: any[] }) => ({ id: p.id, partnershipName: p.partnershipName, criteria: p.criteria || [] }));
+      const completed = (data.completed || []).map(
+        (p: {
+          id: number;
+          partnershipId: number;
+          partnershipName: string;
+          criteria: any[];
+          startedAt?: string | null;
+          completedAt?: string | null;
+        }) => ({
+          id: p.id,
+          partnershipId: p.partnershipId,
+          partnershipName: p.partnershipName,
+          criteria: p.criteria || [],
+          startedAt: p.startedAt ?? null,
+          completedAt: p.completedAt ?? null,
+        })
+      );
       setCompletedPartnerships(completed);
     } catch (error) {
       console.error('Error refreshing completed partnerships:', error);
@@ -1445,17 +1515,37 @@ const hasSeededMockDataRef = useRef(false);
       const count = Number(criteria?.count);
       return sum + (Number.isFinite(count) && count > 0 ? count : 1);
     }, 0);
-    const activePartnershipDoneCount = selectedPartnership
-      ? doneEntries.filter((entry) => entry.partnershipName === selectedPartnership).reduce((sum, entry) => {
-          const extras = Array.isArray(entry.selectedExtras) ? entry.selectedExtras.length : 0;
-          return sum + 1 + extras;
-        }, 0)
+    const nameSet = selectedPartnership
+      ? buildPartnershipNameMatchSet(
+          selectedPartnershipId,
+          selectedPartnership,
+          availablePartnerships,
+          fullPartnerships
+        )
+      : null;
+    const activePartnershipDoneCount = nameSet && nameSet.size > 0
+      ? doneEntries
+          .filter((entry) => {
+            const n = normalizePartnerName(entry.partnershipName);
+            return n !== '' && nameSet.has(n);
+          })
+          .reduce((sum, entry) => {
+            const extras = Array.isArray(entry.selectedExtras) ? entry.selectedExtras.length : 0;
+            return sum + 1 + extras;
+          }, 0)
       : 0;
     const completedCriteria =
       totalCriteria > 0 ? Math.min(activePartnershipDoneCount, totalCriteria) : activePartnershipDoneCount;
 
     return { completedCriteria, totalCriteria };
-  }, [openSourceColumns, selectedPartnership, activePartnershipCriteria]);
+  }, [
+    openSourceColumns,
+    selectedPartnership,
+    selectedPartnershipId,
+    availablePartnerships,
+    fullPartnerships,
+    activePartnershipCriteria,
+  ]);
 
   const filteredAppColumns = useMemo(() => {
     if (applicationsFilter === 'allTime') return appColumns;
@@ -1520,31 +1610,134 @@ const hasSeededMockDataRef = useRef(false);
       done: [],
     };
 
-    // First apply time filter
-    if (openSourceFilter === 'allTime') {
+    // Browsing completed history should not be hidden by "This Month".
+    const effectiveTimeFilter: BoardTimeFilter = viewingCompletedPartnershipName ? 'allTime' : openSourceFilter;
+
+    if (effectiveTimeFilter === 'allTime') {
       filtered = { ...openSourceColumns };
     } else {
       (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
-        if (openSourceFilter === 'modifiedThisMonth') {
+        if (effectiveTimeFilter === 'modifiedThisMonth') {
           filtered[columnId] = openSourceColumns[columnId].filter(entry =>
-            isWithinCurrentMonth(entry.dateModified)
+            isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
           );
         }
       });
     }
 
-    // Then apply partnership filter - use viewing completed partnership if set, else current
-    const partnershipFilter = viewingCompletedPartnershipName ?? selectedPartnership;
-    if (partnershipFilter) {
+    const completedForView = viewingCompletedPartnershipName
+      ? completedPartnerships.find(
+          c => normalizePartnerName(c.partnershipName) === normalizePartnerName(viewingCompletedPartnershipName)
+        )
+      : undefined;
+
+    let nameSet: Set<string> | null = null;
+    if (viewingCompletedPartnershipName) {
+      nameSet = buildPartnershipNameMatchSet(
+        completedForView?.partnershipId ?? null,
+        viewingCompletedPartnershipName,
+        availablePartnerships,
+        fullPartnerships
+      );
+    } else if (selectedPartnership) {
+      nameSet = buildPartnershipNameMatchSet(
+        selectedPartnershipId,
+        selectedPartnership,
+        availablePartnerships,
+        fullPartnerships
+      );
+    }
+
+    if (nameSet && nameSet.size > 0) {
+      const isActiveView = Boolean(selectedPartnership && !viewingCompletedPartnershipName);
       (Object.keys(filtered) as OpenSourceColumnId[]).forEach(columnId => {
-        filtered[columnId] = filtered[columnId].filter(entry =>
-          entry.partnershipName === partnershipFilter
-        );
+        filtered[columnId] = filtered[columnId].filter(entry => {
+          const n = normalizePartnerName(entry.partnershipName);
+          if (n === '') return isActiveView;
+          return nameSet!.has(n);
+        });
       });
     }
 
+    if (selectedPartnership && !viewingCompletedPartnershipName) {
+      const total = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
+        (acc, k) => acc + filtered[k as OpenSourceColumnId].length,
+        0
+      );
+      const timeTotal = (Object.keys(openSourceColumns) as OpenSourceColumnId[]).reduce(
+        (acc, k) => {
+          const arr =
+            effectiveTimeFilter === 'allTime'
+              ? openSourceColumns[k]
+              : openSourceColumns[k].filter(entry => isWithinCurrentMonth(openSourceDateForMonthFilter(entry)));
+          return acc + arr.length;
+        },
+        0
+      );
+      if (total === 0 && timeTotal > 0) {
+        const fallback: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+          plan: [],
+          babyStep: [],
+          inProgress: [],
+          done: [],
+        };
+        (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
+          fallback[columnId] =
+            effectiveTimeFilter === 'allTime'
+              ? [...openSourceColumns[columnId]]
+              : openSourceColumns[columnId].filter(entry =>
+                  isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
+                );
+        });
+        return fallback;
+      }
+    }
+
+    if (viewingCompletedPartnershipName) {
+      const total = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
+        (acc, k) => acc + filtered[k as OpenSourceColumnId].length,
+        0
+      );
+      const start = parseIsoDate(completedForView?.startedAt ?? null);
+      const end = parseIsoDate(completedForView?.completedAt ?? null);
+      if (total === 0 && start) {
+        const windowFiltered: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+          plan: [],
+          babyStep: [],
+          inProgress: [],
+          done: [],
+        };
+        (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
+          windowFiltered[columnId] = openSourceColumns[columnId].filter(entry => {
+            const d = entryDateForCompletedWindow(entry);
+            if (!d) return false;
+            if (d < start) return false;
+            if (end && d > end) return false;
+            return true;
+          });
+        });
+        const windowTotal = (Object.keys(windowFiltered) as OpenSourceColumnId[]).reduce(
+          (acc, k) => acc + windowFiltered[k as OpenSourceColumnId].length,
+          0
+        );
+        if (windowTotal > 0) {
+          return windowFiltered;
+        }
+      }
+    }
+
     return filtered;
-  }, [openSourceColumns, openSourceFilter, selectedPartnership, viewingCompletedPartnershipName, isWithinCurrentMonth]);
+  }, [
+    openSourceColumns,
+    openSourceFilter,
+    selectedPartnership,
+    selectedPartnershipId,
+    viewingCompletedPartnershipName,
+    completedPartnerships,
+    availablePartnerships,
+    fullPartnerships,
+    isWithinCurrentMonth,
+  ]);
 
   const handleTabClick = (tabId: string) => {
     setActiveTab(tabId);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1726,6 +1726,34 @@ const hasSeededMockDataRef = useRef(false);
       }
     }
 
+    const finalTotal = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
+      (acc, k) => acc + filtered[k as OpenSourceColumnId].length,
+      0
+    );
+    if (finalTotal === 0) {
+      const base: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+        plan: [],
+        babyStep: [],
+        inProgress: [],
+        done: [],
+      };
+      (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
+        base[columnId] =
+          effectiveTimeFilter === 'allTime'
+            ? [...openSourceColumns[columnId]]
+            : openSourceColumns[columnId].filter(entry =>
+                isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
+              );
+      });
+      const baseTotal = (Object.keys(base) as OpenSourceColumnId[]).reduce(
+        (acc, k) => acc + base[k as OpenSourceColumnId].length,
+        0
+      );
+      if (baseTotal > 0) {
+        return base;
+      }
+    }
+
     return filtered;
   }, [
     openSourceColumns,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,11 +7,13 @@ import { handleSignIn } from '@/components/auth-actions';
 export default function Page() {
   const [onboardingProgress, setOnboardingProgress] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  const [mounted, setMounted] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
   const [isInstructor, setIsInstructor] = useState<boolean>(false);
 
   // Fetch user's onboarding progress and instructor status on component mount
   useEffect(() => {
+    setMounted(true);
     const fetchStatus = async () => {
       try {
         const [userRes, instructorRes] = await Promise.all([
@@ -88,12 +90,16 @@ export default function Page() {
               <p className="text-base sm:text-lg lg:text-xl text-gray-300 mb-6 sm:mb-8 max-w-2xl mx-auto leading-relaxed px-2">
                 OSRB helps you track your job search journey and build a comprehensive resume based on your applications, networking, and skill development. Master the four key habits that lead to success.
               </p>
-              <button 
+              <button
                 onClick={handleGoToDashboard}
-                disabled={loading}
-                className="bg-electric-blue hover:bg-blue-600 text-white px-6 sm:px-8 py-3 sm:py-4 rounded-lg font-bold text-base sm:text-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-disabled={!mounted || loading}
+                className={`bg-electric-blue text-white px-6 sm:px-8 py-3 sm:py-4 rounded-lg font-bold text-base sm:text-lg transition-colors ${
+                  !mounted || loading
+                    ? 'opacity-50 cursor-not-allowed'
+                    : 'hover:bg-blue-600'
+                }`}
               >
-                {loading ? 'Loading...' : 'Go to Dashboard'}
+                Go to Dashboard
               </button>
             </div>
           </section>


### PR DESCRIPTION
### Notes

No cursor summary here now. This is me writing my paragraph on what I think happened. It was just a 'simple' filtering issue. What led to my panic was in my local database, My completed cards were deleted to which I'll explain how in a bit. I'll first explain what may have happened why the original cards were not showing up, my theory at least.

---
### The Most Likely Scenario Why The Cards Seemingly Disappeared

We shortened the names of the partners in the json file, that was done a while ago, but I don't think the database updated... yet. I think it got updated when we added a new partnership, Piranavan S., which made us needing to **_reseed_** the database. With the new reseeding, it updated the names to the shorter ones in the database, and now all the filters couldn't find the cards, hence why the cards weren't showing up until now. With this, I asked Cursor to make it 'less strict' in finding these names with its filtering logic.

---
### Why I Panicked Thinking There Was Data Loss (TO REITERATE, There Was No Data Loss Luckily!)

In my local database, I was testing the switching of partnerships and abandoning them as the full power instructor a while back. It looked like it work, which it did successfully resets the progress. The issue was that there was no safeguards to keep the **_completed partnership cards_**, and I didn't notice them. In my own database, they were deleted. I only noticed when looking at our recent non-crisis of why aren't the cards showing up. When I tried to look at my staging vercel through studio, I must have had a filter on, as I didn't see the completed partnership cards I tested there. That's when panic ensured and made possibly many unnecessary changes. _When you told me to look at the cards again_, there the damn cards were, the completed partnership ones. That's when it hit me, it was just a damn filtering problem, just the same as _above_. That's when I was reminded that you said data loss shouldn't happen at all, there's no instructor going around switching or abandoning partnerships to have caused dataloss in the first place, we are the only 2 full power instructors here.... At this juncture, **_AFTER_** fixing the filtering issue, I asked cursor how to prevent an instructor from deleting completed cards. We then proceeded to harden and bulletproof the logic of switching and abandoning partnerships, making sure old completed partnership cards won't be deleted.

---
### Proposal To Prevent This Filtering Issue?
Ids should have been used instead of partnership names for relational links, we should probably change the schema to do so. Lesson to be learned here for me? Think of always using unique ids to do... most things with databases.

---
### Bigger Lesson/Moral of the Story??
I need to test more thoroughly. Make unit tests with the help of cursor. Learn Playwright site testing so I don't have to test so thoroughly every time.