### PR TITLE
Email warning count reset

### DIFF
--- a/app/__tests__/inactive-warning-cron.test.ts
+++ b/app/__tests__/inactive-warning-cron.test.ts
@@ -1,0 +1,78 @@
+jest.mock("@/db", () => ({
+  prisma: {
+    user: {
+      updateMany: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/app/lib/email", () => ({
+  sendEmail: jest.fn(),
+  buildInactivityWarningEmail: jest.fn(() => ({ subject: "first", text: "first", html: "<p>first</p>" })),
+  buildSecondWarningEmail: jest.fn(() => ({ subject: "second", text: "second", html: "<p>second</p>" })),
+  buildRemovalNoticeEmail: jest.fn(() => ({ subject: "removal", text: "removal", html: "<p>removal</p>" })),
+}));
+
+import { GET } from "@/app/api/cron/inactive-warning/route";
+import { prisma } from "@/db";
+import { sendEmail } from "@/app/lib/email";
+
+const mockUpdateMany = prisma.user.updateMany as jest.Mock;
+const mockFindMany = prisma.user.findMany as jest.Mock;
+const mockUpdate = prisma.user.update as jest.Mock;
+const mockSendEmail = sendEmail as jest.Mock;
+
+describe("GET /api/cron/inactive-warning", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CRON_SECRET = "test-cron-secret";
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+    mockFindMany.mockResolvedValue([]);
+    mockUpdate.mockResolvedValue({});
+    mockSendEmail.mockResolvedValue({});
+  });
+
+  it("resets warning state for reactivated users before warning send pass", async () => {
+    const request = new Request("http://localhost:3000/api/cron/inactive-warning", {
+      method: "GET",
+      headers: { authorization: "Bearer test-cron-secret" },
+    });
+
+    const response = await GET(request as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateMany).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          inactivityWarningCount: { gt: 0 },
+          removedFromResumeBook: false,
+        }),
+        data: {
+          inactivityWarningCount: 0,
+          lastInactivityWarningSent: null,
+        },
+      })
+    );
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(body.warningsReset).toBe(1);
+  });
+
+  it("returns 401 when bearer token is missing or invalid", async () => {
+    const request = new Request("http://localhost:3000/api/cron/inactive-warning", {
+      method: "GET",
+      headers: { authorization: "Bearer wrong-token" },
+    });
+
+    const response = await GET(request as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/cron/inactive-warning/route.ts
+++ b/app/api/cron/inactive-warning/route.ts
@@ -39,6 +39,29 @@ export async function GET(request: NextRequest) {
     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
+    const reactivatedUsersWhere = {
+      email: { not: null },
+      partnerships: {
+        some: { status: "active" },
+        none: { status: "completed" },
+      },
+      removedFromResumeBook: false,
+      inactivityWarningCount: { gt: 0 },
+      openSource: {
+        some: { dateModified: { gte: thirtyDaysAgo } },
+      },
+    };
+
+    const resetResult = await prisma.user.updateMany({
+      where: debugMode
+        ? { ...reactivatedUsersWhere, email: { in: DEBUG_TEST_EMAILS } }
+        : reactivatedUsersWhere,
+      data: {
+        inactivityWarningCount: 0,
+        lastInactivityWarningSent: null,
+      },
+    });
+
     const baseWhere = {
       email: { not: null },
       partnerships: {
@@ -134,12 +157,13 @@ export async function GET(request: NextRequest) {
     };
 
     console.log(
-      `Inactivity warnings sent: ${summary.firstWarnings} first, ${summary.secondWarnings} second, ${summary.removalNotices} removals. Failed: ${failed.length}`
+      `Inactivity warnings sent: ${summary.firstWarnings} first, ${summary.secondWarnings} second, ${summary.removalNotices} removals. Failed: ${failed.length}. Reset warnings: ${resetResult.count}`
     );
 
     return NextResponse.json({
       message: "Inactivity warning job completed",
       debugMode,
+      warningsReset: resetResult.count,
       totalProcessed: inactiveUsers.length,
       summary,
       emailsFailed: failed.length,

--- a/scripts/local_tests/seed-inactive-warning-user.ts
+++ b/scripts/local_tests/seed-inactive-warning-user.ts
@@ -1,0 +1,157 @@
+import "dotenv/config";
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import partnershipsData from "../../partnerships/partnerships.json";
+import typesData from "../../partnerships/types.json";
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL environment variable is not set");
+}
+
+const pool = new Pool({ connectionString });
+const adapter = new PrismaPg(pool as any);
+const prisma = new PrismaClient({ adapter }) as any;
+
+const TEST_EMAIL = "local.inactive.warning.krishna@example.com";
+const TEST_NAME = "Local Inactive Warning User";
+const KRISHNA_PARTNERSHIP_ID = 2;
+const BACKDATED_CARD_DATE = new Date("2026-02-25T12:00:00.000Z");
+
+type JsonField = {
+  type?: string;
+  text?: string;
+  helper_video?: string;
+};
+
+type TypeDef = {
+  is_primary?: boolean;
+  metric?: string;
+  plan_column_fields?: JsonField[];
+  baby_step_column_fields?: JsonField[];
+  proof_of_completion_column_fields?: JsonField[];
+  proof_of_completion?: JsonField[];
+};
+
+function resolveKrishnaCards() {
+  const partnership = partnershipsData.partnerships.find((p) => p.id === KRISHNA_PARTNERSHIP_ID);
+  if (!partnership) {
+    throw new Error("Krishna partnership definition not found in partnerships.json");
+  }
+
+  return {
+    partnershipName: partnership.name,
+    criteria: partnership.criteria,
+  };
+}
+
+async function main() {
+  const now = Date.now();
+  const eightDaysAgo = new Date(now - 8 * 24 * 60 * 60 * 1000);
+  const { partnershipName, criteria } = resolveKrishnaCards();
+
+  await prisma.partnership.upsert({
+    where: { id: KRISHNA_PARTNERSHIP_ID },
+    update: {
+      name: partnershipName,
+    },
+    create: {
+      id: KRISHNA_PARTNERSHIP_ID,
+      name: partnershipName,
+      linkedIn: "",
+      company: "",
+      role: "",
+      activeUserCount: 0,
+      maxUsers: 5,
+      isActive: true,
+    },
+  });
+
+  const user = await prisma.user.upsert({
+    where: { email: TEST_EMAIL },
+    update: {
+      name: TEST_NAME,
+      inactivityWarningCount: 2,
+      lastInactivityWarningSent: eightDaysAgo,
+      removedFromResumeBook: false,
+    },
+    create: {
+      name: TEST_NAME,
+      email: TEST_EMAIL,
+      inactivityWarningCount: 2,
+      lastInactivityWarningSent: eightDaysAgo,
+      removedFromResumeBook: false,
+    },
+    select: { id: true, email: true },
+  });
+
+  // Keep this seed deterministic by clearing prior board/test records.
+  await prisma.applications_With_Outreach.deleteMany({ where: { userId: user.id } });
+  await prisma.linkedin_Outreach.deleteMany({ where: { userId: user.id } });
+  await prisma.in_Person_Events.deleteMany({ where: { userId: user.id } });
+  await prisma.openSourceEntry.deleteMany({ where: { userId: user.id } });
+  await prisma.userPartnership.deleteMany({ where: { userId: user.id } });
+
+  await prisma.userPartnership.create({
+    data: {
+      userId: user.id,
+      partnershipId: KRISHNA_PARTNERSHIP_ID,
+      status: "active",
+      startedAt: BACKDATED_CARD_DATE,
+      selections: {},
+    },
+  });
+
+  const typeDefs = (typesData.types ?? {}) as Record<string, TypeDef>;
+  const entriesToCreate: any[] = [];
+
+  for (const criterion of criteria as any[]) {
+    if (criterion.type === "multiple_choice") continue;
+    const typeDef = typeDefs[criterion.type] ?? {};
+    if (!typeDef.is_primary) continue;
+
+    const count = criterion.count || 1;
+    for (let i = 0; i < count; i++) {
+      entriesToCreate.push({
+        userId: user.id,
+        partnershipName,
+        criteriaType: criterion.type,
+        metric: typeDef.metric ?? criterion.type,
+        status: "plan",
+        planFields: typeDef.plan_column_fields ?? [],
+        planResponses: {},
+        babyStepFields: typeDef.baby_step_column_fields ?? [],
+        babyStepResponses: {},
+        proofOfCompletion: typeDef.proof_of_completion_column_fields ?? typeDef.proof_of_completion ?? [],
+        proofResponses: {},
+        selectedExtras: [],
+        dateCreated: BACKDATED_CARD_DATE,
+        dateModified: BACKDATED_CARD_DATE,
+      });
+    }
+  }
+
+  if (entriesToCreate.length === 0) {
+    throw new Error("No primary criteria cards were generated for Krishna partnership");
+  }
+
+  await prisma.openSourceEntry.createMany({ data: entriesToCreate });
+
+  console.log("Local inactive warning test user seeded.");
+  console.log(`Email: ${user.email}`);
+  console.log("State: inactivityWarningCount=2, last warning sent 8+ days ago, inactive 30+ days.");
+  console.log(`Cards seeded in fresh layout (all in plan) from partnership contract. Total cards: ${entriesToCreate.length}.`);
+  console.log(`All card dates backdated to ${BACKDATED_CARD_DATE.toISOString().slice(0, 10)}.`);
+}
+
+main()
+  .catch((error) => {
+    console.error("Failed to seed local inactive warning user:", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await pool.end();
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
Made it so that when the cron email check runs, to reset the count for users are active again.

### How

- Cron runs, does normal stuff with additions below
- Finds users with:
  - `inactivityWarningCount > 0`
  - `removedFromResumeBook = false`
  - active partnership conditions
  - and at least one `openSource.dateModified >= 30` days ago (recent activity)
- Those with above conditions, writes `0` to `inactivityWarningCount`

### How to test
- I made a script made to run locally, `../scripts/local_tests/seed-inactive-warning-user.ts`
- run it with `pnpm tsx  scripts/local_tests/seed-inactive-warning-user.ts`
- trigger the cron script locally
- Confirm with prisma studio

---
### Notes
I made a jest unit test as well, to my understanding, it tests only the function that resets `inactivityWarningCount` under certain conditions. No E2E testing. Worry not though, I did test it, E2E, manually myself. Now I see the a potential use for Playwright's testing... it should make my testing time after code changes much shorter.