### PR TITLE
Added a script to shorten partnership's last names

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "prisma:generate:nvm": "PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH prisma generate",
     "prisma:db:push:nvm": "PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH prisma db push --accept-data-loss",
     "prisma:seed:nvm": "PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH prisma db seed",
+    "partnerships:shorten-last-names": "tsx scripts/shorten-partnership-last-names.ts",
+    "partnerships:shorten-last-names:apply": "tsx scripts/shorten-partnership-last-names.ts --apply",
     "build": "pnpm run prisma:generate:nvm && pnpm run prisma:db:push:nvm && pnpm run prisma:seed:nvm && next build",
     "build:nvm": "pnpm run build",
     "dev": "next dev -H 0.0.0.0",

--- a/scripts/shorten-partnership-last-names.ts
+++ b/scripts/shorten-partnership-last-names.ts
@@ -1,0 +1,69 @@
+import "dotenv/config";
+import { prisma } from "../db";
+
+type OpenSourceNameRow = {
+  partnershipName: string;
+};
+
+function toShortName(name: string): string | null {
+  const trimmed = name.trim().replace(/\s+/g, " ");
+  if (!trimmed) return null;
+
+  const parts = trimmed.split(" ");
+  if (parts.length < 2) return null;
+
+  const first = parts[0];
+  const last = parts[parts.length - 1];
+
+  // Target only clear full last names (letters only, no punctuation)
+  if (!/^[A-Za-z]+$/.test(last)) return null;
+
+  const short = `${first} ${last.charAt(0).toUpperCase()}.`;
+  if (short === trimmed) return null;
+  return short;
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+
+  const rows = await prisma.openSourceEntry.findMany({
+    select: { partnershipName: true },
+    distinct: ["partnershipName"],
+    orderBy: { partnershipName: "asc" },
+  });
+
+  const candidates = rows
+    .map((row: OpenSourceNameRow) => {
+      const nextName = toShortName(row.partnershipName);
+      return nextName ? { before: row.partnershipName, after: nextName } : null;
+    })
+    .filter((v): v is { before: string; after: string } => v !== null);
+
+  console.log(`Found ${candidates.length} OpenSourceEntry partnership name(s) to shorten.`);
+  if (candidates.length > 0) {
+    console.table(candidates);
+  }
+
+  if (!apply) {
+    console.log("Dry run only. Re-run with --apply to persist changes.");
+    return;
+  }
+
+  for (const row of candidates) {
+    await prisma.openSourceEntry.updateMany({
+      where: { partnershipName: row.before },
+      data: { partnershipName: row.after },
+    });
+  }
+
+  console.log(`Updated ${candidates.length} OpenSourceEntry partnership name value(s).`);
+}
+
+main()
+  .catch((error) => {
+    console.error("Failed to shorten OpenSourceEntry partnershipName values:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
- Names are still not showing up due to `OpenSourceEntry.partnershipName` still have the full last names.
- This PR won't immediately fix the issue, the script needs to be manually run.

### Option 1:

- Run the script locally on my computer (after I backed up the database, of course)

### Option 2:

- Run it from Vercel's console.
  1. Go to Vercel dashboard → click on out project.
  2. Open the shell/console
  3. Run these commands:
    - `pnpm run partnerships:shorten-last-names`
    - `pnpm run partnerships:shorten-last-names:apply`
  4. First command is a dry run, to show you what names it found, and what it'll change to.
  5. Second command applies it for real.