### PR TITLE
Unit tests for opensource cards

### DIFF
--- a/app/__tests__/open-source-filter.test.ts
+++ b/app/__tests__/open-source-filter.test.ts
@@ -1,0 +1,147 @@
+import type { OpenSourceColumnId, OpenSourceEntry } from "@/app/dashboard/components/types";
+import { getFilteredOpenSourceColumns } from "@/app/dashboard/lib/open-source-filter";
+
+const COLUMNS: OpenSourceColumnId[] = ["plan", "babyStep", "inProgress", "done"];
+
+function makeColumns(rows: Partial<OpenSourceEntry>[]): Record<OpenSourceColumnId, OpenSourceEntry[]> {
+  const out: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+    plan: [],
+    babyStep: [],
+    inProgress: [],
+    done: [],
+  };
+  rows.forEach((r, idx) => {
+    const status = (r.status ?? "plan") as OpenSourceColumnId;
+    out[status].push({
+      id: r.id ?? idx + 1,
+      partnershipName: r.partnershipName ?? "",
+      status: status,
+      userId: r.userId ?? "u1",
+      criteriaType: r.criteriaType ?? "issue",
+      metric: r.metric ?? "m",
+      selectedExtras: r.selectedExtras ?? [],
+      planFields: r.planFields ?? [],
+      planResponses: r.planResponses ?? {},
+      babyStepFields: r.babyStepFields ?? [],
+      babyStepResponses: r.babyStepResponses ?? {},
+      proofOfCompletion: r.proofOfCompletion ?? [],
+      proofResponses: r.proofResponses ?? {},
+      dateCreated: r.dateCreated ?? "2026-04-10T12:00:00.000Z",
+      dateModified: r.dateModified ?? "2026-04-11T12:00:00.000Z",
+    });
+  });
+  return out;
+}
+
+function total(columns: Record<OpenSourceColumnId, OpenSourceEntry[]>): number {
+  return COLUMNS.reduce((acc, c) => acc + columns[c].length, 0);
+}
+
+describe("getFilteredOpenSourceColumns", () => {
+  const isWithinCurrentMonth = (value?: string | null) => {
+    if (!value) return false;
+    return value.startsWith("2026-04");
+  };
+
+  const baseParams = {
+    openSourceFilter: "allTime" as const,
+    selectedPartnership: null as string | null,
+    selectedPartnershipId: null as number | null,
+    viewingCompletedPartnershipName: null as string | null,
+    completedPartnerships: [] as Array<{
+      id: number;
+      partnershipName: string;
+      partnershipId?: number;
+      startedAt?: string | null;
+      completedAt?: string | null;
+    }>,
+    availablePartnerships: [] as Array<{ id: number; name: string }>,
+    fullPartnerships: [] as Array<{ id: number; name: string }>,
+    isWithinCurrentMonth,
+  };
+
+  it("shows active cards despite display-name drift via alias set", () => {
+    const openSourceColumns = makeColumns([
+      { id: 1, status: "plan", partnershipName: "Kevin M." },
+      { id: 2, status: "done", partnershipName: "Someone Else" },
+    ]);
+
+    const filtered = getFilteredOpenSourceColumns({
+      ...baseParams,
+      openSourceColumns,
+      selectedPartnership: "Kevin Mershon",
+      selectedPartnershipId: 7,
+      availablePartnerships: [{ id: 7, name: "Kevin M." }],
+      fullPartnerships: [{ id: 7, name: "Kevin M." }],
+    });
+
+    expect(total(filtered)).toBe(1);
+    expect(filtered.plan[0]?.partnershipName).toBe("Kevin M.");
+  });
+
+  it("does not leak current cards when viewing an empty completed partnership", () => {
+    const openSourceColumns = makeColumns([
+      { id: 1, status: "plan", partnershipName: "Current Partner" },
+      { id: 2, status: "done", partnershipName: "Current Partner" },
+    ]);
+
+    const filtered = getFilteredOpenSourceColumns({
+      ...baseParams,
+      openSourceColumns,
+      selectedPartnership: "Current Partner",
+      viewingCompletedPartnershipName: "Completed With No Cards",
+      completedPartnerships: [
+        {
+          id: 101,
+          partnershipName: "Completed With No Cards",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          completedAt: "2026-01-31T23:59:59.000Z",
+        },
+      ],
+    });
+
+    expect(total(filtered)).toBe(0);
+  });
+
+  it("uses completed date-window fallback when name filter has zero matches", () => {
+    const openSourceColumns = makeColumns([
+      { id: 1, status: "plan", partnershipName: "Other Name", dateCreated: "2026-03-15T00:00:00.000Z" },
+      { id: 2, status: "done", partnershipName: "Other Name", dateCreated: "2026-03-20T00:00:00.000Z" },
+      { id: 3, status: "done", partnershipName: "Other Name", dateCreated: "2026-04-20T00:00:00.000Z" },
+    ]);
+
+    const filtered = getFilteredOpenSourceColumns({
+      ...baseParams,
+      openSourceColumns,
+      viewingCompletedPartnershipName: "Target Completed",
+      completedPartnerships: [
+        {
+          id: 222,
+          partnershipName: "Target Completed",
+          startedAt: "2026-03-01T00:00:00.000Z",
+          completedAt: "2026-03-31T23:59:59.000Z",
+        },
+      ],
+    });
+
+    expect(total(filtered)).toBe(2);
+    expect(filtered.done).toHaveLength(1);
+  });
+
+  it("falls back to time-filtered rows when active name filtering removes all cards", () => {
+    const openSourceColumns = makeColumns([
+      { id: 1, status: "plan", partnershipName: "Name A", dateModified: "2026-04-10T00:00:00.000Z" },
+      { id: 2, status: "done", partnershipName: "Name B", dateModified: "2026-04-11T00:00:00.000Z" },
+    ]);
+
+    const filtered = getFilteredOpenSourceColumns({
+      ...baseParams,
+      openSourceColumns,
+      openSourceFilter: "modifiedThisMonth",
+      selectedPartnership: "No Match Name",
+      selectedPartnershipId: 99999,
+    });
+
+    expect(total(filtered)).toBe(2);
+  });
+});

--- a/app/__tests__/open-source-route.test.ts
+++ b/app/__tests__/open-source-route.test.ts
@@ -1,0 +1,57 @@
+jest.mock("@/db", () => ({
+  prisma: {
+    openSourceEntry: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/app/lib/api-user-helper", () => ({
+  canMutateUserDataForRequest: jest.fn(),
+  getUserIdForRequest: jest.fn(),
+}));
+
+import { GET } from "@/app/api/open_source/route";
+import { prisma } from "@/db";
+import { getUserIdForRequest } from "@/app/lib/api-user-helper";
+
+const mockFindMany = prisma.openSourceEntry.findMany as jest.Mock;
+const mockGetUserId = getUserIdForRequest as jest.Mock;
+
+describe("GET /api/open_source", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns stored open source rows for the authenticated user", async () => {
+    mockGetUserId.mockResolvedValue({ userId: "user-1", error: null });
+    mockFindMany.mockResolvedValue([
+      { id: 11, partnershipName: "Kevin M.", status: "plan", userId: "user-1" },
+      { id: 12, partnershipName: "Kevin M.", status: "done", userId: "user-1" },
+    ]);
+
+    const response = await GET(new Request("http://localhost/api/open_source") as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user-1" },
+        orderBy: { dateCreated: "desc" },
+      })
+    );
+    expect(body).toHaveLength(2);
+    expect(body.map((r: any) => r.id)).toEqual([11, 12]);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUserId.mockResolvedValue({ userId: null, error: "Unauthorized" });
+
+    const response = await GET(new Request("http://localhost/api/open_source") as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/app/__tests__/partnership-delete-safety.test.ts
+++ b/app/__tests__/partnership-delete-safety.test.ts
@@ -1,0 +1,212 @@
+jest.mock("@/db", () => ({
+  prisma: {
+    userPartnership: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      findMany: jest.fn(),
+    },
+    openSourceEntry: {
+      count: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    partnership: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+jest.mock("@/app/lib/api-user-helper", () => ({
+  canMutateUserDataForRequest: jest.fn(),
+  getUserIdForRequest: jest.fn(),
+}));
+
+jest.mock("@/app/lib/instructor-auth", () => ({
+  getInstructorSession: jest.fn(),
+}));
+
+import { DELETE, POST } from "@/app/api/users/partnership/route";
+import { prisma } from "@/db";
+import { canMutateUserDataForRequest, getUserIdForRequest } from "@/app/lib/api-user-helper";
+import { getInstructorSession } from "@/app/lib/instructor-auth";
+
+const mockPrisma = prisma as any;
+const mockCanMutate = canMutateUserDataForRequest as jest.Mock;
+const mockGetUserId = getUserIdForRequest as jest.Mock;
+const mockGetInstructorSession = getInstructorSession as jest.Mock;
+
+describe("DELETE /api/users/partnership safety", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deletes only active-partnership cards and keeps completed-partnership cards", async () => {
+    mockCanMutate.mockResolvedValue({ allowed: true });
+    mockGetUserId.mockResolvedValue({ userId: "user-1", error: null });
+    mockGetInstructorSession.mockResolvedValue({ instructorId: "inst-1" });
+
+    mockPrisma.userPartnership.findFirst.mockResolvedValue({
+      id: 88,
+      userId: "user-1",
+      partnershipId: 7,
+      status: "active",
+      partnership: { id: 7, name: "Kevin M." },
+    });
+
+    const tx = {
+      userPartnership: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 55,
+            userId: "user-1",
+            partnershipId: 5,
+            status: "completed",
+            partnership: { id: 5, name: "Completed Partner" },
+          },
+        ]),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      openSourceEntry: {
+        count: jest
+          .fn()
+          .mockResolvedValueOnce(2) // targetCount
+          .mockResolvedValueOnce(8), // totalUserCount
+        deleteMany: jest.fn().mockResolvedValue({ count: 2 }),
+      },
+      partnership: {
+        update: jest.fn().mockResolvedValue({}),
+      },
+    };
+
+    mockPrisma.$transaction.mockImplementation(async (cb: any) => cb(tx));
+
+    const response = await DELETE(
+      new Request("http://localhost/api/users/partnership?userId=user-1", {
+        method: "DELETE",
+      }) as any
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+
+    expect(tx.openSourceEntry.deleteMany).toHaveBeenCalledTimes(1);
+    const deleteArgs = tx.openSourceEntry.deleteMany.mock.calls[0][0];
+
+    expect(deleteArgs.where.userId).toBe("user-1");
+    expect(deleteArgs.where.OR).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          partnershipName: expect.objectContaining({ equals: "Kevin M." }),
+        }),
+      ])
+    );
+    expect(deleteArgs.where.OR).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          partnershipName: expect.objectContaining({ equals: "Completed Partner" }),
+        }),
+      ])
+    );
+  });
+});
+
+describe("POST /api/users/partnership switch safety", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("on instructor switch, deletes only previous active-partnership cards", async () => {
+    mockCanMutate.mockResolvedValue({ allowed: true });
+    mockGetUserId.mockResolvedValue({ userId: "user-1", error: null });
+    mockGetInstructorSession.mockResolvedValue({ instructorId: "inst-1" });
+
+    mockPrisma.userPartnership.findFirst
+      .mockResolvedValueOnce({
+        id: 88,
+        userId: "user-1",
+        partnershipId: 7,
+        status: "active",
+        partnership: { id: 7, name: "Kevin M." },
+      })
+      .mockResolvedValueOnce(null); // alreadyCompleted
+
+    mockPrisma.partnership.findUnique.mockResolvedValue({
+      id: 9,
+      isActive: true,
+      activeUserCount: 0,
+      maxUsers: 5,
+      name: "New Partner",
+    });
+
+    mockPrisma.userPartnership.findMany.mockResolvedValue([
+      {
+        id: 55,
+        userId: "user-1",
+        partnershipId: 5,
+        status: "completed",
+        partnership: { id: 5, name: "Completed Partner" },
+      },
+    ]);
+
+    mockPrisma.openSourceEntry.count
+      .mockResolvedValueOnce(2) // targetCount
+      .mockResolvedValueOnce(8); // totalUserCount
+    mockPrisma.openSourceEntry.deleteMany.mockResolvedValue({ count: 2 });
+
+    mockPrisma.$transaction.mockImplementation(async (arg: any) => {
+      if (typeof arg === "function") {
+        const tx = {
+          userPartnership: {
+            update: jest.fn().mockResolvedValue({}),
+            create: jest.fn().mockResolvedValue({
+              id: 99,
+              userId: "user-1",
+              partnershipId: 9,
+              status: "active",
+              selections: {},
+              partnership: { id: 9, name: "New Partner" },
+            }),
+          },
+          partnership: {
+            update: jest.fn().mockResolvedValue({}),
+          },
+          openSourceEntry: {
+            create: jest.fn().mockResolvedValue({}),
+          },
+        };
+        return arg(tx);
+      }
+      return [];
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/users/partnership?userId=user-1", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ partnershipId: 9, multipleChoiceSelections: {} }),
+      }) as any
+    );
+    expect(response.status).toBe(200);
+
+    expect(mockPrisma.openSourceEntry.deleteMany).toHaveBeenCalledTimes(1);
+    const deleteArgs = mockPrisma.openSourceEntry.deleteMany.mock.calls[0][0];
+
+    expect(deleteArgs.where.userId).toBe("user-1");
+    expect(deleteArgs.where.OR).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          partnershipName: expect.objectContaining({ equals: "Kevin M." }),
+        }),
+      ])
+    );
+    expect(deleteArgs.where.OR).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          partnershipName: expect.objectContaining({ equals: "Completed Partner" }),
+        }),
+      ])
+    );
+  });
+});

--- a/app/__tests__/smoke.test.ts
+++ b/app/__tests__/smoke.test.ts
@@ -1,83 +1,34 @@
-/**
- * Simple smoke tests to verify the site loads correctly
- * 
- * This test suite checks that key files exist and can be found.
- * 
- * Note: For a more comprehensive test that verifies the entire site compiles
- * and works correctly, run `npm run build` which will check:
- * - TypeScript compilation
- * - Next.js build process
- * - All page and API route compilation
- * - Prisma schema validation
- * 
- * This is the best way to verify "does the site load correctly" end-to-end.
- */
+jest.mock("@/db", () => ({
+  prisma: {
+    openSourceEntry: {},
+    userPartnership: {},
+    partnership: {},
+  },
+}));
 
-import * as fs from 'fs';
-import * as path from 'path';
+jest.mock("@/app/lib/api-user-helper", () => ({
+  canMutateUserDataForRequest: jest.fn(),
+  getUserIdForRequest: jest.fn(),
+}));
 
-describe('Site Smoke Tests - File Existence', () => {
-  const rootDir = path.resolve(__dirname, '../..');
+import { GET as openSourceGET } from "@/app/api/open_source/route";
+import {
+  GET as partnershipGET,
+  POST as partnershipPOST,
+  PUT as partnershipPUT,
+  DELETE as partnershipDELETE,
+} from "@/app/api/users/partnership/route";
 
-  describe('Key Pages Exist', () => {
-    it('should have homepage file', () => {
-      const homepagePath = path.join(rootDir, 'app', 'page.tsx');
-      expect(fs.existsSync(homepagePath)).toBe(true);
-    });
-
-    it('should have instructor dashboard page', () => {
-      const instructorPath = path.join(rootDir, 'app', 'instructor', 'dashboard', 'page.tsx');
-      expect(fs.existsSync(instructorPath)).toBe(true);
-    });
-
-    it('should have main dashboard page', () => {
-      const dashboardPath = path.join(rootDir, 'app', 'dashboard', 'page.tsx');
-      expect(fs.existsSync(dashboardPath)).toBe(true);
-    });
+describe("Smoke tests - route/module wiring", () => {
+  it("exposes open_source GET handler", () => {
+    expect(typeof openSourceGET).toBe("function");
   });
 
-  describe('API Routes Exist', () => {
-    it('should have applications_with_outreach route', () => {
-      const routePath = path.join(rootDir, 'app', 'api', 'applications_with_outreach', 'route.ts');
-      expect(fs.existsSync(routePath)).toBe(true);
-    });
-
-    it('should have linkedin_outreach route', () => {
-      const routePath = path.join(rootDir, 'app', 'api', 'linkedin_outreach', 'route.ts');
-      expect(fs.existsSync(routePath)).toBe(true);
-    });
-
-    it('should have in_person_events route', () => {
-      const routePath = path.join(rootDir, 'app', 'api', 'in_person_events', 'route.ts');
-      expect(fs.existsSync(routePath)).toBe(true);
-    });
-
-    it('should have instructor students route', () => {
-      const routePath = path.join(rootDir, 'app', 'api', 'instructor', 'students', 'route.ts');
-      expect(fs.existsSync(routePath)).toBe(true);
-    });
-  });
-
-  describe('Configuration Files Exist', () => {
-    it('should have next.config.mjs', () => {
-      const configPath = path.join(rootDir, 'next.config.mjs');
-      expect(fs.existsSync(configPath)).toBe(true);
-    });
-
-    it('should have package.json', () => {
-      const packagePath = path.join(rootDir, 'package.json');
-      expect(fs.existsSync(packagePath)).toBe(true);
-    });
-
-    it('should have tsconfig.json', () => {
-      const tsconfigPath = path.join(rootDir, 'tsconfig.json');
-      expect(fs.existsSync(tsconfigPath)).toBe(true);
-    });
-
-    it('should have jest.config.js', () => {
-      const jestPath = path.join(rootDir, 'jest.config.js');
-      expect(fs.existsSync(jestPath)).toBe(true);
-    });
+  it("exposes partnership route handlers", () => {
+    expect(typeof partnershipGET).toBe("function");
+    expect(typeof partnershipPOST).toBe("function");
+    expect(typeof partnershipPUT).toBe("function");
+    expect(typeof partnershipDELETE).toBe("function");
   });
 });
 

--- a/app/dashboard/lib/open-source-filter.ts
+++ b/app/dashboard/lib/open-source-filter.ts
@@ -1,0 +1,222 @@
+import partnershipsData from "@/partnerships/partnerships.json";
+import type {
+  BoardTimeFilter,
+  OpenSourceColumnId,
+  OpenSourceEntry,
+} from "../components/types";
+
+type CompletedPartnershipLite = {
+  partnershipId?: number;
+  partnershipName: string;
+  startedAt?: string | null;
+  completedAt?: string | null;
+};
+
+type NameOption = { id: number; name: string };
+
+type Params = {
+  openSourceColumns: Record<OpenSourceColumnId, OpenSourceEntry[]>;
+  openSourceFilter: BoardTimeFilter;
+  selectedPartnership: string | null;
+  selectedPartnershipId: number | null;
+  viewingCompletedPartnershipName: string | null;
+  completedPartnerships: CompletedPartnershipLite[];
+  availablePartnerships: NameOption[];
+  fullPartnerships: NameOption[];
+  isWithinCurrentMonth: (value?: string | null) => boolean;
+};
+
+function normalizePartnerName(s: string | null | undefined): string {
+  return (s ?? "").trim().toLowerCase();
+}
+
+function buildPartnershipNameMatchSet(
+  partnershipId: number | null,
+  displayName: string | null,
+  availablePartnerships: NameOption[],
+  fullPartnerships: NameOption[]
+): Set<string> {
+  const out = new Set<string>();
+  if (displayName) out.add(normalizePartnerName(displayName));
+  if (partnershipId != null) {
+    const fromJson = partnershipsData.partnerships.find((p) => p.id === partnershipId)?.name;
+    if (fromJson) out.add(normalizePartnerName(fromJson));
+    const fromAvail = availablePartnerships.find((p) => p.id === partnershipId)?.name;
+    if (fromAvail) out.add(normalizePartnerName(fromAvail));
+    const fromFull = fullPartnerships.find((p) => p.id === partnershipId)?.name;
+    if (fromFull) out.add(normalizePartnerName(fromFull));
+  }
+  return out;
+}
+
+function openSourceDateForMonthFilter(entry: OpenSourceEntry): string | null {
+  return entry.dateModified ?? entry.dateCreated ?? null;
+}
+
+function parseIsoDate(value?: string | null): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d;
+}
+
+function entryDateForCompletedWindow(entry: OpenSourceEntry): Date | null {
+  return parseIsoDate(entry.dateCreated ?? entry.dateModified ?? null);
+}
+
+export function getFilteredOpenSourceColumns({
+  openSourceColumns,
+  openSourceFilter,
+  selectedPartnership,
+  selectedPartnershipId,
+  viewingCompletedPartnershipName,
+  completedPartnerships,
+  availablePartnerships,
+  fullPartnerships,
+  isWithinCurrentMonth,
+}: Params): Record<OpenSourceColumnId, OpenSourceEntry[]> {
+  let filtered: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+    plan: [],
+    babyStep: [],
+    inProgress: [],
+    done: [],
+  };
+
+  const effectiveTimeFilter: BoardTimeFilter = viewingCompletedPartnershipName ? "allTime" : openSourceFilter;
+
+  if (effectiveTimeFilter === "allTime") {
+    filtered = { ...openSourceColumns };
+  } else {
+    (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach((columnId) => {
+      filtered[columnId] = openSourceColumns[columnId].filter((entry) =>
+        isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
+      );
+    });
+  }
+
+  const completedForView = viewingCompletedPartnershipName
+    ? completedPartnerships.find(
+        (c) => normalizePartnerName(c.partnershipName) === normalizePartnerName(viewingCompletedPartnershipName)
+      )
+    : undefined;
+
+  let nameSet: Set<string> | null = null;
+  if (viewingCompletedPartnershipName) {
+    nameSet = buildPartnershipNameMatchSet(
+      completedForView?.partnershipId ?? null,
+      viewingCompletedPartnershipName,
+      availablePartnerships,
+      fullPartnerships
+    );
+  } else if (selectedPartnership) {
+    nameSet = buildPartnershipNameMatchSet(
+      selectedPartnershipId,
+      selectedPartnership,
+      availablePartnerships,
+      fullPartnerships
+    );
+  }
+
+  if (nameSet && nameSet.size > 0) {
+    const isActiveView = Boolean(selectedPartnership && !viewingCompletedPartnershipName);
+    (Object.keys(filtered) as OpenSourceColumnId[]).forEach((columnId) => {
+      filtered[columnId] = filtered[columnId].filter((entry) => {
+        const n = normalizePartnerName(entry.partnershipName);
+        if (n === "") return isActiveView;
+        return nameSet.has(n);
+      });
+    });
+  }
+
+  if (selectedPartnership && !viewingCompletedPartnershipName) {
+    const total = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
+      (acc, k) => acc + filtered[k].length,
+      0
+    );
+    const timeTotal = (Object.keys(openSourceColumns) as OpenSourceColumnId[]).reduce((acc, k) => {
+      const arr =
+        effectiveTimeFilter === "allTime"
+          ? openSourceColumns[k]
+          : openSourceColumns[k].filter((entry) => isWithinCurrentMonth(openSourceDateForMonthFilter(entry)));
+      return acc + arr.length;
+    }, 0);
+    if (total === 0 && timeTotal > 0) {
+      const fallback: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+        plan: [],
+        babyStep: [],
+        inProgress: [],
+        done: [],
+      };
+      (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach((columnId) => {
+        fallback[columnId] =
+          effectiveTimeFilter === "allTime"
+            ? [...openSourceColumns[columnId]]
+            : openSourceColumns[columnId].filter((entry) =>
+                isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
+              );
+      });
+      return fallback;
+    }
+  }
+
+  if (viewingCompletedPartnershipName) {
+    const total = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
+      (acc, k) => acc + filtered[k].length,
+      0
+    );
+    const start = parseIsoDate(completedForView?.startedAt ?? null);
+    const end = parseIsoDate(completedForView?.completedAt ?? null);
+    if (total === 0 && start) {
+      const windowFiltered: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+        plan: [],
+        babyStep: [],
+        inProgress: [],
+        done: [],
+      };
+      (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach((columnId) => {
+        windowFiltered[columnId] = openSourceColumns[columnId].filter((entry) => {
+          const d = entryDateForCompletedWindow(entry);
+          if (!d) return false;
+          if (d < start) return false;
+          if (end && d > end) return false;
+          return true;
+        });
+      });
+      const windowTotal = (Object.keys(windowFiltered) as OpenSourceColumnId[]).reduce(
+        (acc, k) => acc + windowFiltered[k].length,
+        0
+      );
+      if (windowTotal > 0) return windowFiltered;
+    }
+  }
+
+  if (!viewingCompletedPartnershipName) {
+    const finalTotal = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
+      (acc, k) => acc + filtered[k].length,
+      0
+    );
+    if (finalTotal === 0) {
+      const base: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
+        plan: [],
+        babyStep: [],
+        inProgress: [],
+        done: [],
+      };
+      (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach((columnId) => {
+        base[columnId] =
+          effectiveTimeFilter === "allTime"
+            ? [...openSourceColumns[columnId]]
+            : openSourceColumns[columnId].filter((entry) =>
+                isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
+              );
+      });
+      const baseTotal = (Object.keys(base) as OpenSourceColumnId[]).reduce(
+        (acc, k) => acc + base[k].length,
+        0
+      );
+      if (baseTotal > 0) return base;
+    }
+  }
+
+  return filtered;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import CoffeeChatsTab from './components/CoffeeChatsTab';
 import EventsTab from './components/EventsTab';
 import OpenSourceTab from './components/OpenSourceTab';
 import { getApiHeaders } from '@/app/lib/api-helpers';
+import { getFilteredOpenSourceColumns } from './lib/open-source-filter';
 import type {
   Application,
   ApplicationStatus,
@@ -40,46 +41,6 @@ import {
   APPLICATION_COMPLETION_COLUMNS,
   EVENT_COMPLETION_COLUMNS,
 } from './components/types';
-import partnershipsData from '@/partnerships/partnerships.json';
-
-function normalizePartnerName(s: string | null | undefined): string {
-  return (s ?? '').trim().toLowerCase();
-}
-
-function buildPartnershipNameMatchSet(
-  partnershipId: number | null,
-  displayName: string | null,
-  availablePartnerships: Array<{ id: number; name: string }>,
-  fullPartnerships: Array<{ id: number; name: string }>
-): Set<string> {
-  const out = new Set<string>();
-  if (displayName) out.add(normalizePartnerName(displayName));
-  if (partnershipId != null) {
-    const fromJson = partnershipsData.partnerships.find(p => p.id === partnershipId)?.name;
-    if (fromJson) out.add(normalizePartnerName(fromJson));
-    const fromAvail = availablePartnerships.find(p => p.id === partnershipId)?.name;
-    if (fromAvail) out.add(normalizePartnerName(fromAvail));
-    const fromFull = fullPartnerships.find(p => p.id === partnershipId)?.name;
-    if (fromFull) out.add(normalizePartnerName(fromFull));
-  }
-  return out;
-}
-
-function openSourceDateForMonthFilter(entry: OpenSourceEntry): string | null {
-  return entry.dateModified ?? entry.dateCreated ?? null;
-}
-
-function parseIsoDate(value?: string | null): Date | null {
-  if (!value) return null;
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return null;
-  return d;
-}
-
-function entryDateForCompletedWindow(entry: OpenSourceEntry): Date | null {
-  return parseIsoDate(entry.dateCreated ?? entry.dateModified ?? null);
-}
-
 // ===== MOCK DATA FEATURE TOGGLE START =====
 // Toggle this flag or comment out the seeding effect below to disable mock data.
 const ENABLE_DASHBOARD_MOCKS = false;
@@ -1603,160 +1564,17 @@ const hasSeededMockDataRef = useRef(false);
   }, [eventColumns, eventsFilter, isWithinCurrentMonth]);
 
   const filteredOpenSourceColumns = useMemo(() => {
-    let filtered: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
-      plan: [],
-      babyStep: [],
-      inProgress: [],
-      done: [],
-    };
-
-    // Browsing completed history should not be hidden by "This Month".
-    const effectiveTimeFilter: BoardTimeFilter = viewingCompletedPartnershipName ? 'allTime' : openSourceFilter;
-
-    if (effectiveTimeFilter === 'allTime') {
-      filtered = { ...openSourceColumns };
-    } else {
-      (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
-        if (effectiveTimeFilter === 'modifiedThisMonth') {
-          filtered[columnId] = openSourceColumns[columnId].filter(entry =>
-            isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
-          );
-        }
-      });
-    }
-
-    const completedForView = viewingCompletedPartnershipName
-      ? completedPartnerships.find(
-          c => normalizePartnerName(c.partnershipName) === normalizePartnerName(viewingCompletedPartnershipName)
-        )
-      : undefined;
-
-    let nameSet: Set<string> | null = null;
-    if (viewingCompletedPartnershipName) {
-      nameSet = buildPartnershipNameMatchSet(
-        completedForView?.partnershipId ?? null,
-        viewingCompletedPartnershipName,
-        availablePartnerships,
-        fullPartnerships
-      );
-    } else if (selectedPartnership) {
-      nameSet = buildPartnershipNameMatchSet(
-        selectedPartnershipId,
-        selectedPartnership,
-        availablePartnerships,
-        fullPartnerships
-      );
-    }
-
-    if (nameSet && nameSet.size > 0) {
-      const isActiveView = Boolean(selectedPartnership && !viewingCompletedPartnershipName);
-      (Object.keys(filtered) as OpenSourceColumnId[]).forEach(columnId => {
-        filtered[columnId] = filtered[columnId].filter(entry => {
-          const n = normalizePartnerName(entry.partnershipName);
-          if (n === '') return isActiveView;
-          return nameSet!.has(n);
-        });
-      });
-    }
-
-    if (selectedPartnership && !viewingCompletedPartnershipName) {
-      const total = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
-        (acc, k) => acc + filtered[k as OpenSourceColumnId].length,
-        0
-      );
-      const timeTotal = (Object.keys(openSourceColumns) as OpenSourceColumnId[]).reduce(
-        (acc, k) => {
-          const arr =
-            effectiveTimeFilter === 'allTime'
-              ? openSourceColumns[k]
-              : openSourceColumns[k].filter(entry => isWithinCurrentMonth(openSourceDateForMonthFilter(entry)));
-          return acc + arr.length;
-        },
-        0
-      );
-      if (total === 0 && timeTotal > 0) {
-        const fallback: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
-          plan: [],
-          babyStep: [],
-          inProgress: [],
-          done: [],
-        };
-        (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
-          fallback[columnId] =
-            effectiveTimeFilter === 'allTime'
-              ? [...openSourceColumns[columnId]]
-              : openSourceColumns[columnId].filter(entry =>
-                  isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
-                );
-        });
-        return fallback;
-      }
-    }
-
-    if (viewingCompletedPartnershipName) {
-      const total = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
-        (acc, k) => acc + filtered[k as OpenSourceColumnId].length,
-        0
-      );
-      const start = parseIsoDate(completedForView?.startedAt ?? null);
-      const end = parseIsoDate(completedForView?.completedAt ?? null);
-      if (total === 0 && start) {
-        const windowFiltered: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
-          plan: [],
-          babyStep: [],
-          inProgress: [],
-          done: [],
-        };
-        (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
-          windowFiltered[columnId] = openSourceColumns[columnId].filter(entry => {
-            const d = entryDateForCompletedWindow(entry);
-            if (!d) return false;
-            if (d < start) return false;
-            if (end && d > end) return false;
-            return true;
-          });
-        });
-        const windowTotal = (Object.keys(windowFiltered) as OpenSourceColumnId[]).reduce(
-          (acc, k) => acc + windowFiltered[k as OpenSourceColumnId].length,
-          0
-        );
-        if (windowTotal > 0) {
-          return windowFiltered;
-        }
-      }
-    }
-
-    if (!viewingCompletedPartnershipName) {
-      const finalTotal = (Object.keys(filtered) as OpenSourceColumnId[]).reduce(
-        (acc, k) => acc + filtered[k as OpenSourceColumnId].length,
-        0
-      );
-      if (finalTotal === 0) {
-        const base: Record<OpenSourceColumnId, OpenSourceEntry[]> = {
-          plan: [],
-          babyStep: [],
-          inProgress: [],
-          done: [],
-        };
-        (Object.keys(openSourceColumns) as OpenSourceColumnId[]).forEach(columnId => {
-          base[columnId] =
-            effectiveTimeFilter === 'allTime'
-              ? [...openSourceColumns[columnId]]
-              : openSourceColumns[columnId].filter(entry =>
-                  isWithinCurrentMonth(openSourceDateForMonthFilter(entry))
-                );
-        });
-        const baseTotal = (Object.keys(base) as OpenSourceColumnId[]).reduce(
-          (acc, k) => acc + base[k as OpenSourceColumnId].length,
-          0
-        );
-        if (baseTotal > 0) {
-          return base;
-        }
-      }
-    }
-
-    return filtered;
+    return getFilteredOpenSourceColumns({
+      openSourceColumns,
+      openSourceFilter,
+      selectedPartnership,
+      selectedPartnershipId,
+      viewingCompletedPartnershipName,
+      completedPartnerships,
+      availablePartnerships,
+      fullPartnerships,
+      isWithinCurrentMonth,
+    });
   }, [
     openSourceColumns,
     openSourceFilter,


### PR DESCRIPTION
### Unit Tests

- Added 3 new tests.
  - `app/__tests__/open-source-filter.test.ts`
  - `app/__tests__/open-source-route.test.ts`
  - `app/__tests__/partnership-delete-safety.test.ts`
- `open-source-filter.test.ts`
  - Tests what we panicked about, why the cards wouldn't show up.
- `open-source-route.test.ts`
  - API route tests for Open Source data retrieval:
  - confirms `/api/open_source` returns existing rows for authenticated users
  - confirms unauthenticated requests correctly return `401`
- `partnership-delete-safety.test.ts`
  - abandon flow only targets active-partnership card scope
  - switch flow only targets previous active-partnership card scope
  - makes sure completed-partnership cards are not included in deletion criteria

### Related Changes
- Refactored dashboard filtering into a testable helper:
  - extracted Open Source filtering logic from `app/dashboard/page.tsx` into `app/dashboard/lib/open-source-filter.ts`
  - page now calls the shared helper (behavior preserved, easier to test)

### Kind of Unrelated Changes
- Trimmed smoke tests:
  - replaced file-existence checks with route/module wiring checks
  - updated smoke test mocks to avoid pulling real auth/DB runtime internals

## Test Plan
- In the console of you choice:
  - `pnpm test -- open-source-filter`
  - `pnpm test -- open-source-route partnership-delete-safety open-source-filter`
  - `pnpm test -- partnership-delete-safety`
  - `pnpm test -- smoke`
  - `pnpm test -- inactive-warning-cron`

## Notes
Technically, github will run the gamut of tests above. Every time we make a new test, Github's CI will run the new test automatically.