### PR TITLE
NEWER Parallax home

### DIFF
--- a/components/home/IntroActionsSection.tsx
+++ b/components/home/IntroActionsSection.tsx
@@ -30,7 +30,7 @@ export function IntroActionsSection({
       <div className="relative z-[2] h-full w-full overflow-hidden">
         <div
           ref={contentRef}
-          className="will-change-transform flex w-full items-start justify-center px-4 pt-[14vh] sm:px-8 sm:pt-[16vh]"
+          className="will-change-transform flex w-full items-start justify-center px-4 pt-[8vh] sm:px-8 sm:pt-[10vh]"
         >
           <div className="w-full max-w-6xl">
             <div className="text-center">

--- a/components/home/IntroActionsSection.tsx
+++ b/components/home/IntroActionsSection.tsx
@@ -11,6 +11,7 @@ type IntroActionsSectionProps = {
   sectionStyle?: CSSProperties;
   sectionRef: RefObject<HTMLElement | null>;
   contentRef: RefObject<HTMLDivElement | null>;
+  onSignUp: () => void;
 };
 
 export function IntroActionsSection({
@@ -18,6 +19,7 @@ export function IntroActionsSection({
   sectionStyle,
   sectionRef,
   contentRef,
+  onSignUp,
 }: IntroActionsSectionProps) {
   return (
     <section
@@ -52,10 +54,17 @@ export function IntroActionsSection({
                 </p>
                 <h3 className="mt-4 text-2xl font-bold text-black sm:text-3xl">Start your pathway</h3>
                 <p className="mt-4 flex-1 text-lg leading-relaxed text-gray-700 sm:text-xl">
-                  Use <span className="font-semibold text-black">Sign In</span> in the navbar above to
-                  get started, track open source achievements, and work toward hiring-manager-defined
+                  Sign up to track open source achievements and work toward hiring-manager-defined
                   benchmarks.
                 </p>
+                <button
+                  type="button"
+                  onClick={onSignUp}
+                  className="mt-8 inline-flex w-full cursor-pointer items-center justify-center rounded-lg px-6 py-4 text-lg font-semibold text-white transition-colors hover:opacity-90 sm:w-auto"
+                  style={{ backgroundColor: ACCENT_CORAL }}
+                >
+                  Sign up
+                </button>
               </div>
 
               <div className="flex min-h-[280px] flex-col rounded-2xl border border-light-steel-blue/40 bg-white p-8 shadow-sm sm:min-h-[320px] sm:p-10 md:min-h-[360px]">

--- a/components/home/IntroScrollNav.tsx
+++ b/components/home/IntroScrollNav.tsx
@@ -1,75 +1,67 @@
 'use client';
 
-import { useId, useState } from 'react';
-import type { IntroNavSection } from './introScrollNav';
+import {
+  getIntroNavProgressBarTranslateX,
+  type IntroNavSection,
+} from './introScrollNav';
 
 const ACCENT_CORAL = '#F57360';
 
 type IntroScrollNavProps = {
   sections: IntroNavSection[];
   activeId: string;
+  activeProgress: number;
   onSelect: (section: IntroNavSection) => void;
 };
 
-export function IntroScrollNav({ sections, activeId, onSelect }: IntroScrollNavProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const menuId = useId();
-
+export function IntroScrollNav({
+  sections,
+  activeId,
+  activeProgress,
+  onSelect,
+}: IntroScrollNavProps) {
   if (sections.length === 0) return null;
 
-  const handleSelect = (section: IntroNavSection) => {
-    onSelect(section);
-    setIsOpen(false);
-  };
-
   return (
-    <div className="pointer-events-auto fixed left-2 top-[calc(var(--navbar-height)+1rem)] z-[30] sm:left-5">
-      <button
-        type="button"
-        aria-expanded={isOpen}
-        aria-controls={menuId}
-        aria-label={isOpen ? 'Close section navigation' : 'Open section navigation'}
-        onClick={() => setIsOpen((open) => !open)}
-        className="flex h-10 w-10 items-center justify-center rounded-sm border border-gray-200 bg-white/90 shadow-sm backdrop-blur-sm transition-colors hover:border-gray-300 sm:h-11 sm:w-11"
-      >
-        <span className="flex flex-col gap-1" aria-hidden>
-          <span className="block h-0.5 w-5 rounded-full bg-gray-700" />
-          <span className="block h-0.5 w-5 rounded-full bg-gray-700" />
-          <span className="block h-0.5 w-5 rounded-full bg-gray-700" />
-        </span>
-      </button>
+    <nav
+      aria-label="Intro sections"
+      className="pointer-events-auto fixed left-2 top-[calc(var(--navbar-height)+1rem)] z-[30] flex flex-col gap-1.5 sm:left-5 sm:gap-2.5"
+    >
+      {sections.map((section) => {
+        const isActive = section.id === activeId;
+        const barTranslateX = isActive
+          ? getIntroNavProgressBarTranslateX(activeProgress)
+          : getIntroNavProgressBarTranslateX(0);
 
-      <nav
-        id={menuId}
-        aria-label="Intro sections"
-        aria-hidden={!isOpen}
-        className={`mt-2 flex max-h-[min(70vh,24rem)] flex-col gap-1.5 overflow-hidden rounded-sm border border-gray-200 bg-white/95 p-2 shadow-sm backdrop-blur-sm transition-[max-height,opacity,transform,margin] duration-200 ease-out sm:gap-2.5 sm:p-2.5 ${
-          isOpen
-            ? 'pointer-events-auto max-h-[min(70vh,24rem)] translate-y-0 opacity-100'
-            : 'pointer-events-none max-h-0 -translate-y-1 border-transparent p-0 opacity-0 shadow-none'
-        }`}
-      >
-        {sections.map((section) => {
-          const isActive = section.id === activeId;
-          return (
-            <button
-              key={section.id}
-              type="button"
-              tabIndex={isOpen ? 0 : -1}
-              aria-current={isActive ? 'true' : undefined}
-              onClick={() => handleSelect(section)}
-              className={`origin-left text-left transition-all duration-200 ${
-                isActive
-                  ? 'text-xs font-semibold tracking-tight sm:text-base md:text-lg'
-                  : 'text-[9px] font-medium text-gray-400 hover:text-gray-600 sm:text-[10px] md:text-xs'
-              }`}
+        return (
+          <button
+            key={section.id}
+            type="button"
+            aria-current={isActive ? 'true' : undefined}
+            onClick={() => onSelect(section)}
+            className={`relative overflow-hidden rounded-sm px-1 py-0.5 text-left sm:px-1.5 sm:py-1 ${
+              isActive
+                ? 'text-xs font-semibold tracking-tight sm:text-base md:text-lg'
+                : 'text-[9px] font-medium text-gray-400 hover:text-gray-600 sm:text-[10px] md:text-xs'
+            }`}
+          >
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 will-change-transform"
+              style={{
+                backgroundColor: isActive ? `${ACCENT_CORAL}22` : 'transparent',
+                transform: `translateX(${barTranslateX})`,
+              }}
+            />
+            <span
+              className="relative z-10 block"
               style={isActive ? { color: ACCENT_CORAL } : undefined}
             >
               {section.label}
-            </button>
-          );
-        })}
-      </nav>
-    </div>
+            </span>
+          </button>
+        );
+      })}
+    </nav>
   );
 }

--- a/components/home/OsrIntroScroll.tsx
+++ b/components/home/OsrIntroScroll.tsx
@@ -7,12 +7,13 @@ import { useGSAP } from '@gsap/react';
 import { HOME_ASSETS } from './homeAssets';
 import { buildIntroScrollPhases, getOsrScrollHeightVh, getPageIndicatorScrollPhase } from './osrIntroTimeline';
 import {
-  ACTIONS_CONTENT_END_Y,
   ACTIONS_CONTENT_START_Y,
   PERSONAL_BAR_CONTENT_START_Y,
   TYPING_DESCRIPTIONS,
   getOsrSceneConfig,
+  getScrollTrackBottomPx,
   getViewportBelowNavbar,
+  measureActionsContentHeight,
   measurePersonalBarContentHeight,
   syncScrollTrackAnimations,
 } from './osrScrollUtils';
@@ -144,6 +145,12 @@ export function OsrIntroScroll() {
   const scrollToNavSection = useCallback((section: IntroNavSection) => {
     const track = scrollTrackRef.current;
     if (!track) return;
+
+    if (section.id === 'contact') {
+      // DOM bottom — matches manual scroll; jumpVh alone stops ~1 viewport short.
+      window.scrollTo({ top: getScrollTrackBottomPx(track), behavior: 'smooth' });
+      return;
+    }
 
     const anchorJump = section.anchorJump;
     if (anchorJump) {
@@ -370,27 +377,26 @@ export function OsrIntroScroll() {
             microsoftContentHeight: measurePersonalBarContentHeight(microsoftPersonalBarContent),
             metaContentHeight: measurePersonalBarContentHeight(metaPersonalBarContent),
             affiliationsContentHeight: measurePersonalBarContentHeight(affiliationsContent),
+            actionsContentHeight: measureActionsContentHeight(actionsContent),
           });
           const {
             whoopEndY: whoopContentEndY,
             microsoftEndY: microsoftContentEndY,
             metaEndY: metaContentEndY,
             affiliationsEndY,
+            actionsEndY,
           } = motion;
 
           scrollTrack.style.height = `${scrollTrackEndVh * 100}vh`;
           setScrollHeightVh(scrollTrackEndVh);
           setIntroNavSections(
-            buildIntroNavSections({
-              whoSectionIn: phases.whoSectionIn,
-              whoContentIn: phases.whoContentIn,
-              howSectionIn: phases.howSectionIn,
-              whoopPersonalBarScroll: phases.whoopPersonalBarScroll,
-              microsoftPersonalBarScroll: phases.microsoftPersonalBarScroll,
-              metaPersonalBarScroll: phases.metaPersonalBarScroll,
-              affiliationsScroll: phases.affiliationsScroll,
-              actionsScroll: phases.actionsScroll,
-            }),
+            buildIntroNavSections(
+              {
+                whoopPersonalBarScroll: phases.whoopPersonalBarScroll,
+                actionsScroll: phases.actionsScroll,
+              },
+              scrollTrackEndVh,
+            ),
           );
           const attachSectionCrossfade = (
             phase: { at: number; durationPercent: number },
@@ -619,18 +625,20 @@ export function OsrIntroScroll() {
             affiliationsEndY,
           );
 
-          attachSectionCrossfade(
-            phases.affiliationsToActions,
-            sectionAffiliations,
-            sectionActions,
-          );
-
-          attachContentScroll(
-            phases.actionsScroll,
-            actionsContent,
-            ACTIONS_CONTENT_END_Y,
-            undefined,
-            ACTIONS_CONTENT_START_Y,
+          attachScene(
+            scrollTrack,
+            phases.actionsScroll.at,
+            phases.actionsScroll.durationPercent,
+            gsap
+              .timeline({ defaults: { ease: 'none' } })
+              .fromTo(sectionAffiliations, { autoAlpha: 1 }, { autoAlpha: 0, ...SCRUB_DEFAULTS }, 0)
+              .fromTo(sectionActions, { autoAlpha: 0 }, { autoAlpha: 1, ...SCRUB_DEFAULTS }, 0)
+              .fromTo(
+                actionsContent,
+                { y: ACTIONS_CONTENT_START_Y },
+                { y: actionsEndY, ease: 'none', duration: 1 },
+                0,
+              ),
           );
 
           removeTopScrubSyncListener = attachTopScrubSync();

--- a/components/home/OsrIntroScroll.tsx
+++ b/components/home/OsrIntroScroll.tsx
@@ -17,6 +17,7 @@ import {
   measurePersonalBarContentHeight,
   syncScrollTrackAnimations,
 } from './osrScrollUtils';
+import { handleSignIn } from '@/components/auth-actions';
 import { TypingHeroLine } from './TypingHeroLine';
 import { IntroActionsSection } from './IntroActionsSection';
 import { MetaPersonalBarSection } from './MetaPersonalBarSection';
@@ -940,6 +941,9 @@ export function OsrIntroScroll() {
         sectionStyle={sectionShellStyle}
         sectionRef={sectionActionsRef}
         contentRef={actionsContentRef}
+        onSignUp={() => {
+          void handleSignIn();
+        }}
       />
     </div>
   );

--- a/components/home/OsrIntroScroll.tsx
+++ b/components/home/OsrIntroScroll.tsx
@@ -5,7 +5,7 @@ import gsap from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { useGSAP } from '@gsap/react';
 import { HOME_ASSETS } from './homeAssets';
-import { buildIntroScrollPhases, getOsrScrollHeightVh } from './osrIntroTimeline';
+import { buildIntroScrollPhases, getOsrScrollHeightVh, getPageIndicatorScrollPhase } from './osrIntroTimeline';
 import {
   ACTIONS_CONTENT_END_Y,
   ACTIONS_CONTENT_START_Y,
@@ -26,6 +26,7 @@ import { computeScrollVhForAnchorTarget } from './introScrollJump';
 import {
   buildIntroNavSections,
   getActiveIntroNavId,
+  getIntroNavSectionProgress,
   type IntroNavSection,
 } from './introScrollNav';
 
@@ -78,6 +79,7 @@ function applyIntroStartFrame(
   sectionMetaPersonalBar: HTMLElement,
   sectionAffiliations: HTMLElement,
   sectionActions: HTMLElement,
+  pageIndicator?: HTMLElement | null,
 ) {
   gsap.set(sectionZero, { autoAlpha: 1 });
   gsap.set(sectionOne, { autoAlpha: 0 });
@@ -88,6 +90,9 @@ function applyIntroStartFrame(
   gsap.set(sectionMetaPersonalBar, { autoAlpha: 0 });
   gsap.set(sectionAffiliations, { autoAlpha: 0 });
   gsap.set(sectionActions, { autoAlpha: 0 });
+  if (pageIndicator) {
+    gsap.set(pageIndicator, { opacity: 1, top: '90%', yPercent: 0 });
+  }
 }
 
 function readIsCompactViewport(width: number) {
@@ -109,6 +114,7 @@ export function OsrIntroScroll() {
   const [stageScale, setStageScale] = useState(1);
   const [introNavSections, setIntroNavSections] = useState<IntroNavSection[]>([]);
   const [activeNavId, setActiveNavId] = useState('intro');
+  const [activeNavProgress, setActiveNavProgress] = useState(0);
   const scrollTrackRef = useRef<HTMLDivElement>(null);
   const sectionZeroRef = useRef<HTMLElement>(null);
   const sectionOneRef = useRef<HTMLElement>(null);
@@ -168,7 +174,9 @@ export function OsrIntroScroll() {
       const vh = getViewportBelowNavbar();
       const relativePx = Math.max(window.scrollY - track.offsetTop, 0);
       const relativeVh = relativePx / vh;
-      setActiveNavId(getActiveIntroNavId(introNavSections, relativeVh));
+      const activeId = getActiveIntroNavId(introNavSections, relativeVh);
+      setActiveNavId(activeId);
+      setActiveNavProgress(getIntroNavSectionProgress(introNavSections, relativeVh, activeId));
     };
 
     updateActive();
@@ -293,6 +301,8 @@ export function OsrIntroScroll() {
         return undefined;
       }
 
+      const pageIndicator = introRoot.querySelector<HTMLElement>('[data-page-indicator]');
+
       const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
       const scheduleLayoutSync = () => {
@@ -319,6 +329,7 @@ export function OsrIntroScroll() {
         gsap.set(affiliationsContent, { y: 0 });
         gsap.set(sectionActions, { opacity: 1 });
         gsap.set(actionsContent, { y: 0 });
+        if (pageIndicator) gsap.set(pageIndicator, { opacity: 0 });
         return;
       }
 
@@ -340,6 +351,7 @@ export function OsrIntroScroll() {
             sectionMetaPersonalBar,
             sectionAffiliations,
             sectionActions,
+            pageIndicator,
           );
           gsap.set(whoopPersonalBarBgLogo, { opacity: 0, scale: 0.88 });
           gsap.set(microsoftPersonalBarBgLogo, { opacity: 0, scale: 0.88 });
@@ -456,6 +468,23 @@ export function OsrIntroScroll() {
 
           attachScene(
             scrollTrack,
+            phases.whoContentIn.at,
+            phases.whoContentIn.durationPercent,
+            gsap.fromTo(whoWeAreContent, { opacity: 0 }, { opacity: 1, ...SCRUB_DEFAULTS }),
+          );
+
+          const pageIndicatorScroll = getPageIndicatorScrollPhase(phases.howToWhoop);
+          if (pageIndicator) {
+            attachScene(
+              scrollTrack,
+              pageIndicatorScroll.at,
+              pageIndicatorScroll.durationPercent,
+              gsap.fromTo(pageIndicator, { top: '90%' }, { top: '-50%', ...SCRUB_DEFAULTS }),
+            );
+          }
+
+          attachScene(
+            scrollTrack,
             phases.whoSectionIn.at,
             phases.whoSectionIn.durationPercent,
             gsap.fromTo(sectionOne, { autoAlpha: 0 }, { autoAlpha: 1, ...SCRUB_DEFAULTS }),
@@ -488,13 +517,6 @@ export function OsrIntroScroll() {
 
           attachScene(
             scrollTrack,
-            phases.whoContentIn.at,
-            phases.whoContentIn.durationPercent,
-            gsap.fromTo(whoWeAreContent, { opacity: 0 }, { opacity: 1, ...SCRUB_DEFAULTS }),
-          );
-
-          attachScene(
-            scrollTrack,
             phases.whoSectionOut.at,
             phases.whoSectionOut.durationPercent,
             gsap.fromTo(sectionOne, { autoAlpha: 1 }, { autoAlpha: 0, ...SCRUB_DEFAULTS }),
@@ -514,7 +536,12 @@ export function OsrIntroScroll() {
               phases.howLettersMove.durationPercent,
               gsap
                 .timeline({ defaults: { ease: 'none' } })
-                .to(howLetterO, { top: '15%', left: '-12%' }, 0)
+                .fromTo(
+                  howLetterO,
+                  { left: '-5%', bottom: '12%', top: 'auto', right: 'auto' },
+                  { left: '-22%', bottom: '16%', ...SCRUB_DEFAULTS },
+                  0,
+                )
                 .to(howLetterR, { bottom: '0%', right: '30%' }, 0)
                 .to(howLetterS, { right: '15%', top: '0%' }, 0),
             );
@@ -525,7 +552,12 @@ export function OsrIntroScroll() {
               phases.howLettersMove.durationPercent,
               gsap
                 .timeline({ defaults: { ease: 'none' } })
-                .to(howLetterO, { top: '-20%', left: '-8%' }, 0)
+                .fromTo(
+                  howLetterO,
+                  { left: '-4%', bottom: '5%', top: 'auto', right: 'auto' },
+                  { left: '-20%', bottom: '16%', ...SCRUB_DEFAULTS },
+                  0,
+                )
                 .to(howLetterR, { bottom: '-35%', right: '30%' }, 0)
                 .to(howLetterS, { right: '22%', top: '-15%' }, 0),
             );
@@ -571,6 +603,15 @@ export function OsrIntroScroll() {
             sectionMetaPersonalBar,
             sectionAffiliations,
           );
+
+          if (pageIndicator) {
+            attachScene(
+              scrollTrack,
+              phases.metaToAffiliations.at,
+              phases.metaToAffiliations.durationPercent,
+              gsap.fromTo(pageIndicator, { opacity: 1 }, { opacity: 0, ...SCRUB_DEFAULTS }),
+            );
+          }
 
           attachContentScroll(
             phases.affiliationsScroll,
@@ -676,7 +717,15 @@ export function OsrIntroScroll() {
       <IntroScrollNav
         sections={introNavSections}
         activeId={activeNavId}
+        activeProgress={activeNavProgress}
         onSelect={scrollToNavSection}
+      />
+
+      <div
+        data-page-indicator
+        className="pointer-events-none fixed left-[20%] z-[8] h-[45%] w-0.5"
+        style={{ backgroundColor: ACCENT_CORAL, top: '90%' }}
+        aria-hidden
       />
 
       {/* Phase 1 — typing hero */}
@@ -758,7 +807,7 @@ export function OsrIntroScroll() {
       >
         <div
           ref={howLetterORef}
-          className={`${letterBase} left-[-5%] top-[20%] md:left-[-4%] md:top-[-10%]`}
+          className={`${letterBase} bottom-[12%] left-[-5%] md:bottom-[5%] md:left-[-4%]`}
           style={{ color: ACCENT_CORAL }}
         >
           O

--- a/components/home/OsrIntroStatic.tsx
+++ b/components/home/OsrIntroStatic.tsx
@@ -12,6 +12,8 @@ import {
 import { StaticIntroActionsSection } from './StaticIntroActionsSection';
 import { StaticIntroNav } from './StaticIntroNav';
 import { StaticPersonalBarSection } from './StaticPersonalBarSection';
+import { STATIC_SECTION_SCROLL_MT } from './staticIntroScrollNav';
+import { TypingHeroLine } from './TypingHeroLine';
 import { TYPING_DESCRIPTIONS } from './osrScrollUtils';
 import {
   WHOOP_LOGO_PATH,
@@ -24,12 +26,12 @@ const ACCENT_CORAL = '#F57360';
 /** Plain stacked homepage intro for mobile browsers (no scroll-scrub / parallax). */
 export function OsrIntroStatic() {
   return (
-    <article className="relative w-full bg-white">
+    <article className="relative w-full bg-white pt-[var(--static-intro-nav-height,3.25rem)]">
       <StaticIntroNav />
 
       <section
         id="intro-zero"
-        className="scroll-mt-[calc(var(--navbar-height)+1rem)] px-5 py-14 sm:px-8 sm:py-16"
+        className={`${STATIC_SECTION_SCROLL_MT} px-5 py-14 sm:px-8 sm:py-16`}
         aria-label="Introduction"
       >
         <div className="mx-auto w-full max-w-3xl">
@@ -39,20 +41,16 @@ export function OsrIntroStatic() {
           >
             Open Source Resume is
           </p>
-          <p className="mt-4 border-b border-[#F57360] pb-4 text-xl font-semibold leading-snug text-[#F57360] sm:text-2xl">
-            {TYPING_DESCRIPTIONS[0]}
-          </p>
-          <ul className="mt-4 space-y-2 text-sm leading-relaxed text-gray-600 sm:text-base">
-            {TYPING_DESCRIPTIONS.slice(1).map((line) => (
-              <li key={line}>{line}</li>
-            ))}
-          </ul>
+          <TypingHeroLine
+            descriptions={TYPING_DESCRIPTIONS}
+            className="mt-4 min-h-[1.8em] border-b border-[#F57360] pb-4 text-xl font-semibold leading-snug text-[#F57360] sm:text-2xl"
+          />
         </div>
       </section>
 
       <section
         id="intro-one"
-        className="scroll-mt-[calc(var(--navbar-height)+1rem)] border-t border-light-steel-blue/30 px-5 py-12 sm:px-8 sm:py-14"
+        className={`${STATIC_SECTION_SCROLL_MT} border-t border-light-steel-blue/30 px-5 py-12 sm:px-8 sm:py-14`}
         aria-labelledby="intro-who-heading"
       >
         <div className="mx-auto w-full max-w-3xl">
@@ -71,7 +69,7 @@ export function OsrIntroStatic() {
 
       <section
         id="intro-two"
-        className="scroll-mt-[calc(var(--navbar-height)+1rem)] border-t border-light-steel-blue/30 px-5 py-12 sm:px-8 sm:py-14"
+        className={`${STATIC_SECTION_SCROLL_MT} border-t border-light-steel-blue/30 px-5 py-12 sm:px-8 sm:py-14`}
         aria-labelledby="intro-how-heading"
       >
         <div className="mx-auto w-full max-w-3xl">
@@ -114,7 +112,7 @@ export function OsrIntroStatic() {
 
       <section
         id="intro-affiliations"
-        className="scroll-mt-[calc(var(--navbar-height)+1rem)] border-t border-light-steel-blue/30 bg-white py-12 sm:py-16"
+        className={`${STATIC_SECTION_SCROLL_MT} border-t border-light-steel-blue/30 bg-white py-12 sm:py-16`}
         aria-labelledby="affiliations-heading"
       >
         <div className="mx-auto w-full max-w-6xl px-4 text-center sm:px-8">

--- a/components/home/StaticIntroActionsSection.tsx
+++ b/components/home/StaticIntroActionsSection.tsx
@@ -1,3 +1,4 @@
+import { handleSignIn } from '@/components/auth-actions';
 import { HIRING_MANAGER_CALENDLY_URL } from './homeCtas';
 
 const ACCENT_CORAL = '#F57360';
@@ -30,10 +31,18 @@ export function StaticIntroActionsSection() {
             </p>
             <h3 className="mt-4 text-2xl font-bold text-black sm:text-3xl">Start your pathway</h3>
             <p className="mt-4 flex-1 text-lg leading-relaxed text-gray-700 sm:text-xl">
-              Use <span className="font-semibold text-black">Sign In</span> in the navbar above to
-              get started, track open source achievements, and work toward hiring-manager-defined
+              Sign up to track open source achievements and work toward hiring-manager-defined
               benchmarks.
             </p>
+            <form action={handleSignIn} className="mt-8">
+              <button
+                type="submit"
+                className="inline-flex w-full cursor-pointer items-center justify-center rounded-lg px-6 py-4 text-lg font-semibold text-white transition-colors hover:opacity-90 sm:w-auto"
+                style={{ backgroundColor: ACCENT_CORAL }}
+              >
+                Sign up
+              </button>
+            </form>
           </div>
 
           <div className="flex min-h-[240px] flex-col rounded-2xl border border-light-steel-blue/40 bg-white p-8 shadow-sm sm:min-h-[280px] sm:p-10">

--- a/components/home/StaticIntroActionsSection.tsx
+++ b/components/home/StaticIntroActionsSection.tsx
@@ -1,5 +1,6 @@
 import { handleSignIn } from '@/components/auth-actions';
 import { HIRING_MANAGER_CALENDLY_URL } from './homeCtas';
+import { STATIC_SECTION_SCROLL_MT } from './staticIntroScrollNav';
 
 const ACCENT_CORAL = '#F57360';
 const ACCENT_TEAL = '#58A4B0';
@@ -8,7 +9,7 @@ export function StaticIntroActionsSection() {
   return (
     <section
       id="intro-actions"
-      className="scroll-mt-[calc(var(--navbar-height)+1rem)] border-t border-light-steel-blue/30 bg-white py-12 sm:py-16"
+      className={`${STATIC_SECTION_SCROLL_MT} border-t border-light-steel-blue/30 bg-white py-12 sm:py-16`}
       aria-labelledby="intro-actions-heading"
     >
       <div className="mx-auto w-full max-w-6xl px-4 sm:px-8">

--- a/components/home/StaticIntroActionsSection.tsx
+++ b/components/home/StaticIntroActionsSection.tsx
@@ -35,7 +35,7 @@ export function StaticIntroActionsSection() {
               Sign up to track open source achievements and work toward hiring-manager-defined
               benchmarks.
             </p>
-            <form action={handleSignIn} className="mt-8">
+            <form action={handleSignIn.bind(null, undefined)} className="mt-8">
               <button
                 type="submit"
                 className="inline-flex w-full cursor-pointer items-center justify-center rounded-lg px-6 py-4 text-lg font-semibold text-white transition-colors hover:opacity-90 sm:w-auto"

--- a/components/home/StaticIntroNav.tsx
+++ b/components/home/StaticIntroNav.tsx
@@ -1,64 +1,118 @@
 'use client';
 
-import { useId, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  STATIC_INTRO_NAV_SECTIONS,
+  getActiveStaticIntroNavId,
+  getStaticIntroNavHeaderOffsetPx,
+  getStaticIntroNavSectionProgress,
+  scrollToStaticIntroNavSection,
+} from './staticIntroScrollNav';
+import { getIntroNavProgressBarTranslateX } from './introScrollNav';
 
 const ACCENT_CORAL = '#F57360';
 
-const STATIC_NAV_LINKS = [
-  { id: 'intro', label: 'Intro', href: '#intro-zero' },
-  { id: 'personal-bars', label: 'Personal Bars', href: '#whoop-bar-heading' },
-  { id: 'contact', label: 'Contact', href: '#intro-actions' },
-] as const;
-
 export function StaticIntroNav() {
-  const [isOpen, setIsOpen] = useState(false);
-  const menuId = useId();
+  const navShellRef = useRef<HTMLDivElement>(null);
+  const [activeId, setActiveId] = useState('intro');
+  const [activeProgress, setActiveProgress] = useState(0);
+
+  const syncNavHeightVariable = useCallback(() => {
+    const height = navShellRef.current?.offsetHeight ?? 52;
+    document.documentElement.style.setProperty('--static-intro-nav-height', `${height}px`);
+  }, []);
+
+  useEffect(() => {
+    syncNavHeightVariable();
+
+    const updateActive = () => {
+      const headerOffsetPx = getStaticIntroNavHeaderOffsetPx();
+      const scrollY = window.scrollY;
+      const nextActiveId = getActiveStaticIntroNavId(
+        STATIC_INTRO_NAV_SECTIONS,
+        scrollY,
+        headerOffsetPx,
+      );
+      setActiveId(nextActiveId);
+      setActiveProgress(
+        getStaticIntroNavSectionProgress(
+          STATIC_INTRO_NAV_SECTIONS,
+          scrollY,
+          nextActiveId,
+          headerOffsetPx,
+        ),
+      );
+    };
+
+    const onViewportChange = () => {
+      syncNavHeightVariable();
+      updateActive();
+    };
+
+    updateActive();
+    window.addEventListener('scroll', updateActive, { passive: true });
+    window.addEventListener('resize', onViewportChange);
+
+    return () => {
+      window.removeEventListener('scroll', updateActive);
+      window.removeEventListener('resize', onViewportChange);
+      document.documentElement.style.removeProperty('--static-intro-nav-height');
+    };
+  }, [syncNavHeightVariable]);
 
   return (
-    <div className="pointer-events-auto fixed left-2 top-[calc(var(--navbar-height)+1rem)] z-[30] sm:left-5">
-      <button
-        type="button"
-        aria-expanded={isOpen}
-        aria-controls={menuId}
-        aria-label={isOpen ? 'Close section navigation' : 'Open section navigation'}
-        onClick={() => setIsOpen((open) => !open)}
-        className="flex h-10 w-10 items-center justify-center rounded-sm border border-gray-200 bg-white/90 shadow-sm backdrop-blur-sm transition-colors hover:border-gray-300 sm:h-11 sm:w-11"
-      >
-        <span className="flex flex-col gap-1" aria-hidden>
-          <span className="block h-0.5 w-5 rounded-full bg-gray-700" />
-          <span className="block h-0.5 w-5 rounded-full bg-gray-700" />
-          <span className="block h-0.5 w-5 rounded-full bg-gray-700" />
-        </span>
-      </button>
+    <div
+      ref={navShellRef}
+      className="pointer-events-none fixed inset-x-0 top-[var(--navbar-height)] z-[30]"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-[calc(100%+1.25rem)]"
+        style={{
+          background:
+            'linear-gradient(to bottom, #ffffff 0%, #ffffff 62%, rgba(255,255,255,0.92) 82%, transparent 100%)',
+        }}
+      />
 
       <nav
-        id={menuId}
         aria-label="Intro sections"
-        aria-hidden={!isOpen}
-        className={`mt-2 flex max-h-[min(70vh,24rem)] flex-col gap-1.5 overflow-hidden rounded-sm border border-gray-200 bg-white/95 p-2 shadow-sm backdrop-blur-sm transition-[max-height,opacity,transform,margin] duration-200 ease-out sm:gap-2.5 sm:p-2.5 ${
-          isOpen
-            ? 'pointer-events-auto max-h-[min(70vh,24rem)] translate-y-0 opacity-100'
-            : 'pointer-events-none max-h-0 -translate-y-1 border-transparent p-0 opacity-0 shadow-none'
-        }`}
+        className="pointer-events-auto relative flex items-stretch justify-center gap-1 px-3 pb-2.5 pt-2 sm:gap-2 sm:px-5 sm:pb-3 sm:pt-2.5"
       >
-        {STATIC_NAV_LINKS.map((link) => (
-          <a
-            key={link.id}
-            href={link.href}
-            tabIndex={isOpen ? 0 : -1}
-            onClick={() => setIsOpen(false)}
-            className="text-[10px] font-medium text-gray-500 transition-colors hover:text-gray-800 sm:text-xs"
-          >
-            {link.label}
-          </a>
-        ))}
-        <p className="mt-1 border-t border-gray-100 pt-2 text-[9px] leading-snug text-gray-400 sm:text-[10px]">
-          Mobile layout —{' '}
-          <span className="font-medium" style={{ color: ACCENT_CORAL }}>
-            scroll
-          </span>{' '}
-          to read each section.
-        </p>
+        {STATIC_INTRO_NAV_SECTIONS.map((section) => {
+          const isActive = section.id === activeId;
+          const barTranslateX = getIntroNavProgressBarTranslateX(isActive ? activeProgress : 0);
+
+          return (
+            <button
+              key={section.id}
+              type="button"
+              aria-current={isActive ? 'true' : undefined}
+              onClick={() => {
+                scrollToStaticIntroNavSection(section, getStaticIntroNavHeaderOffsetPx());
+              }}
+              className={`relative min-w-0 flex-1 overflow-hidden rounded-sm px-1 py-1 text-center sm:px-2 sm:py-1.5 ${
+                isActive
+                  ? 'text-[11px] font-semibold tracking-tight sm:text-sm'
+                  : 'text-[10px] font-medium text-gray-400 hover:text-gray-600 sm:text-xs'
+              }`}
+            >
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-0 will-change-transform"
+                style={{
+                  backgroundColor: isActive ? `${ACCENT_CORAL}22` : 'transparent',
+                  transform: `translateX(${barTranslateX})`,
+                }}
+              />
+              <span
+                className="relative z-10 block truncate"
+                style={isActive ? { color: ACCENT_CORAL } : undefined}
+              >
+                {section.label}
+              </span>
+            </button>
+          );
+        })}
       </nav>
     </div>
   );

--- a/components/home/StaticIntroNav.tsx
+++ b/components/home/StaticIntroNav.tsx
@@ -6,13 +6,8 @@ const ACCENT_CORAL = '#F57360';
 
 const STATIC_NAV_LINKS = [
   { id: 'intro', label: 'Intro', href: '#intro-zero' },
-  { id: 'who', label: 'Who', href: '#intro-who-heading' },
-  { id: 'how', label: 'How', href: '#intro-how-heading' },
-  { id: 'whoop', label: 'Personal Bar 1', href: '#whoop-bar-heading' },
-  { id: 'microsoft', label: 'Personal Bar 2', href: '#microsoft-bar-heading' },
-  { id: 'meta', label: 'Personal Bar 3', href: '#meta-bar-heading' },
-  { id: 'affiliations', label: 'Affiliations', href: '#affiliations-heading' },
-  { id: 'actions', label: "What's next", href: '#intro-actions-heading' },
+  { id: 'personal-bars', label: 'Personal Bars', href: '#whoop-bar-heading' },
+  { id: 'contact', label: 'Contact', href: '#intro-actions' },
 ] as const;
 
 export function StaticIntroNav() {

--- a/components/home/StaticPersonalBarSection.tsx
+++ b/components/home/StaticPersonalBarSection.tsx
@@ -1,5 +1,6 @@
 import { CriterionDetail } from './CriterionDetail';
 import type { PersonalBarCriterion } from './personalBarTypes';
+import { STATIC_SECTION_SCROLL_MT } from './staticIntroScrollNav';
 
 type StaticPersonalBarSectionProps = {
   sectionId: string;
@@ -19,7 +20,7 @@ export function StaticPersonalBarSection({
   return (
     <section
       id={sectionId}
-      className="relative scroll-mt-[calc(var(--navbar-height)+1rem)] overflow-hidden border-t border-light-steel-blue/30 bg-white py-12 sm:py-16"
+      className={`relative ${STATIC_SECTION_SCROLL_MT} overflow-hidden border-t border-light-steel-blue/30 bg-white py-12 sm:py-16`}
       aria-labelledby={headingId}
     >
       <div

--- a/components/home/introScrollNav.ts
+++ b/components/home/introScrollNav.ts
@@ -1,4 +1,4 @@
-import { getPhaseEndVh } from './osrScrollUtils';
+import { getScrollTrackBottomRelativeVh } from './osrScrollUtils';
 
 /**
  * Left-nav sections for the homepage intro scroll story.
@@ -9,16 +9,18 @@ import { getPhaseEndVh } from './osrScrollUtils';
  * navbar, measured from the top of the scroll track.
  *
  * - `startVh` — scroll position where this nav label becomes active
- * - `jumpVh` — scroll target (intro / who / how, or fallback when anchor is missing)
+ * - `jumpVh` — scroll target when anchor jump is unavailable
  *
  * ## Nav jumps
  *
- * **Scroll-content sections** (personal bars, affiliations, actions): on click,
- * `introScrollJump.ts` searches scroll so the heading sits at
- * `SCROLL_CONTENT_HEADING_TOP_VH` below the navbar.
+ * **Intro** — scroll to top of track.
  *
- * **Fixed sections** (who, how): content does not move with scroll — jump targets a
- * scroll phase instead (`whoContentIn` end for Who, `howSectionIn` + offset for How).
+ * **Personal Bars** — `introScrollJump.ts` aligns the first personal-bar heading
+ * below the navbar.
+ *
+ * **Contact** — scroll to the physical track bottom (`getScrollTrackBottomPx` in
+ * `OsrIntroScroll.tsx`); `jumpVh` on that section is the matching below-navbar vh
+ * for progress-bar math only.
  */
 
 type IntroNavAnchorJump = {
@@ -43,23 +45,12 @@ type IntroNavPhase = {
 
 /** Phase subset needed to resolve nav scroll ranges. */
 type IntroNavBuildPhases = {
-  whoSectionIn: IntroNavPhase;
-  whoContentIn: IntroNavPhase;
-  howSectionIn: IntroNavPhase;
   whoopPersonalBarScroll: IntroNavPhase;
-  microsoftPersonalBarScroll: IntroNavPhase;
-  metaPersonalBarScroll: IntroNavPhase;
-  affiliationsScroll: IntroNavPhase;
   actionsScroll: IntroNavPhase;
 };
 
-/** vh below navbar for scroll-content section headings (personal bars, affiliations, actions). */
+/** vh below navbar for scroll-content section headings (personal bars, contact). */
 const SCROLL_CONTENT_HEADING_TOP_VH = 14;
-
-/** Extra scroll (vh) past phase start for fixed overlay sections. Positive = farther down. */
-const JUMP_OFFSET_VH = {
-  how: 0.6,
-} as const;
 
 function scrollContentAnchorJump(
   anchorId: string,
@@ -74,15 +65,13 @@ function scrollContentAnchorJump(
   };
 }
 
-export function buildIntroNavSections(phases: IntroNavBuildPhases): IntroNavSection[] {
-  const who = phases.whoSectionIn.at;
-  const how = phases.howSectionIn.at;
+export function buildIntroNavSections(
+  phases: IntroNavBuildPhases,
+  scrollTrackEndVh: number,
+): IntroNavSection[] {
   const whoop = phases.whoopPersonalBarScroll.at;
-  const microsoft = phases.microsoftPersonalBarScroll.at;
-  const meta = phases.metaPersonalBarScroll.at;
-  const affiliations = phases.affiliationsScroll.at;
   const actions = phases.actionsScroll.at;
-  const scrollEndVh = getPhaseEndVh(phases.actionsScroll);
+  const trackBottomVh = getScrollTrackBottomRelativeVh(scrollTrackEndVh);
 
   return [
     {
@@ -92,71 +81,17 @@ export function buildIntroNavSections(phases: IntroNavBuildPhases): IntroNavSect
       jumpVh: 0,
     },
     {
-      id: 'who',
-      label: 'Who',
-      startVh: who,
-      jumpVh: getPhaseEndVh(phases.whoContentIn),
-    },
-    {
-      id: 'how',
-      label: 'How',
-      startVh: how,
-      jumpVh: how + JUMP_OFFSET_VH.how,
-    },
-    {
-      id: 'whoop',
-      label: 'Personal Bar 1',
+      id: 'personal-bars',
+      label: 'Personal Bars',
       startVh: whoop,
       jumpVh: whoop,
-      anchorJump: scrollContentAnchorJump(
-        'whoop-bar-heading',
-        whoop,
-        getPhaseEndVh(phases.whoopPersonalBarScroll),
-      ),
+      anchorJump: scrollContentAnchorJump('whoop-bar-heading', whoop, actions),
     },
     {
-      id: 'microsoft',
-      label: 'Personal Bar 2',
-      startVh: microsoft,
-      jumpVh: microsoft,
-      anchorJump: scrollContentAnchorJump(
-        'microsoft-bar-heading',
-        microsoft,
-        getPhaseEndVh(phases.microsoftPersonalBarScroll),
-      ),
-    },
-    {
-      id: 'meta',
-      label: 'Personal Bar 3',
-      startVh: meta,
-      jumpVh: meta,
-      anchorJump: scrollContentAnchorJump(
-        'meta-bar-heading',
-        meta,
-        getPhaseEndVh(phases.metaPersonalBarScroll),
-      ),
-    },
-    {
-      id: 'affiliations',
-      label: 'Affiliations',
-      startVh: affiliations,
-      jumpVh: affiliations,
-      anchorJump: scrollContentAnchorJump(
-        'affiliations-heading',
-        affiliations,
-        getPhaseEndVh(phases.affiliationsScroll),
-      ),
-    },
-    {
-      id: 'actions',
-      label: "What's next",
+      id: 'contact',
+      label: 'Contact',
       startVh: actions,
-      jumpVh: scrollEndVh,
-      anchorJump: scrollContentAnchorJump(
-        'intro-actions-heading',
-        actions,
-        scrollEndVh,
-      ),
+      jumpVh: trackBottomVh,
     },
   ];
 }
@@ -174,11 +109,9 @@ export function getActiveIntroNavId(
 }
 
 function getIntroNavSectionEndVh(sections: IntroNavSection[], index: number): number {
-  const section = sections[index];
-  if (section.anchorJump) return section.anchorJump.scrollMaxVh;
   const next = sections[index + 1];
   if (next) return next.startVh;
-  return section.jumpVh;
+  return sections[index].jumpVh;
 }
 
 /** 0 at section start, 1 at section end — drives the active nav progress bar fill. */

--- a/components/home/introScrollNav.ts
+++ b/components/home/introScrollNav.ts
@@ -172,3 +172,34 @@ export function getActiveIntroNavId(
   }
   return active;
 }
+
+function getIntroNavSectionEndVh(sections: IntroNavSection[], index: number): number {
+  const section = sections[index];
+  if (section.anchorJump) return section.anchorJump.scrollMaxVh;
+  const next = sections[index + 1];
+  if (next) return next.startVh;
+  return section.jumpVh;
+}
+
+/** 0 at section start, 1 at section end — drives the active nav progress bar fill. */
+export function getIntroNavSectionProgress(
+  sections: IntroNavSection[],
+  relativeScrollVh: number,
+  sectionId: string,
+): number {
+  const index = sections.findIndex((section) => section.id === sectionId);
+  if (index === -1) return 0;
+
+  const section = sections[index];
+  const endVh = getIntroNavSectionEndVh(sections, index);
+  const span = endVh - section.startVh;
+  if (span <= 0) return 1;
+
+  return Math.min(1, Math.max(0, (relativeScrollVh - section.startVh) / span));
+}
+
+/** Gilroy-style bar: hidden off-left at -101%, fully revealed at 0%. */
+export function getIntroNavProgressBarTranslateX(progress: number): string {
+  const hiddenPercent = -101;
+  return `${hiddenPercent + progress * -hiddenPercent}%`;
+}

--- a/components/home/osrIntroTimeline.ts
+++ b/components/home/osrIntroTimeline.ts
@@ -1,19 +1,19 @@
 /**
  * Homepage scroll phases (viewport-height multiples).
  *
- * Every phase is strictly sequential: each `at` is the end of the previous phase.
+ * **Sequential chain** (`PHASE_ORDER`): each phase `at` is the end of the previous phase.
  * Store only `durationPercent` per phase; `buildIntroScrollPhases` assigns `at`.
  *
- * Pattern for content sections: scroll → crossfade → scroll → crossfade …
- *
- * Parallel phases (same scroll window as another beat, not in PHASE_ORDER):
+ * **Parallel phases** (own scroll window, not in `PHASE_ORDER`):
  * - `whoContentIn` — starts when typing hero is fully gone
- * - page indicator — see getPageIndicatorScrollPhase()
+ * - page indicator — see `getPageIndicatorScrollPhase()`
+ *
+ * Pattern for content sections: scroll → crossfade → scroll → crossfade …
  */
 import {
-  ACTIONS_CONTENT_END_Y,
   ACTIONS_CONTENT_START_VH,
   getAffiliationsContentEndY,
+  getActionsContentEndY,
   getContentScrollTravelVh,
   getMetaContentEndY,
   getPersonalBarContentEndY,
@@ -34,7 +34,7 @@ const OSR_INTRO_PHASE_DURATIONS = {
   whoContentIn: 40,
   whoSectionOut: 40,
   howSectionIn: 30,
-  howLettersMove: 80,
+  howLettersMove: 80, // minimum; resolved to match Who story chapter length
   howToWhoop: 8,
 } as const;
 
@@ -56,7 +56,6 @@ const OSR_CONTENT_PHASE_DURATIONS = {
   metaPersonalBarScroll: 55,
   metaToAffiliations: 32,
   affiliationsScroll: 55,
-  affiliationsToActions: 32,
   actionsScroll: 36,
 } as const;
 
@@ -89,14 +88,25 @@ const PHASE_ORDER = [
   'metaPersonalBarScroll',
   'metaToAffiliations',
   'affiliationsScroll',
-  'affiliationsToActions',
   'actionsScroll',
 ] as const;
 
 type OsrIntroPhaseKey = keyof typeof OSR_INTRO_PHASE_DURATIONS;
 type OsrContentPhaseKey = keyof typeof OSR_CONTENT_PHASE_DURATIONS;
 type OsrSequentialPhaseKey = (typeof PHASE_ORDER)[number];
-export type OsrPhaseKey = OsrSequentialPhaseKey | 'whoContentIn';
+type OsrPhaseKey = OsrSequentialPhaseKey | 'whoContentIn';
+
+/** Fixed overlay beats — Who section visible through `whoSectionOut`. */
+const WHO_STORY_PHASES = ['whoSectionIn', 'whoLettersMove', 'whoSectionOut'] as const satisfies readonly OsrIntroPhaseKey[];
+/** Fixed overlay beats — How section visible through `howToWhoop`. */
+const HOW_STORY_CORE_PHASES = ['howSectionIn', 'howToWhoop'] as const satisfies readonly OsrIntroPhaseKey[];
+
+function getStoryChapterDuration(
+  phaseKeys: readonly OsrIntroPhaseKey[],
+  isMobile: boolean,
+): number {
+  return phaseKeys.reduce((total, key) => total + getIntroPhaseDuration(key, isMobile), 0);
+}
 
 const STAGE_BASE_HEIGHT = 1080;
 const MOBILE_VIEWPORT_HEIGHT = 844;
@@ -106,6 +116,7 @@ const ESTIMATED_CONTENT_HEIGHTS = {
   microsoft: 1100,
   meta: 950,
   affiliations: 500,
+  actions: 680,
 } as const;
 
 type IntroContentMeasurements = {
@@ -115,6 +126,7 @@ type IntroContentMeasurements = {
   microsoftContentHeight: number;
   metaContentHeight: number;
   affiliationsContentHeight: number;
+  actionsContentHeight: number;
 };
 
 type IntroContentMotion = {
@@ -122,6 +134,7 @@ type IntroContentMotion = {
   microsoftEndY: string;
   metaEndY: string;
   affiliationsEndY: string;
+  actionsEndY: string;
 };
 
 function getIntroPhaseDuration(key: OsrIntroPhaseKey, isMobile: boolean): number {
@@ -145,6 +158,7 @@ function estimatedMeasurements(isMobile: boolean): IntroContentMeasurements {
     microsoftContentHeight: ESTIMATED_CONTENT_HEIGHTS.microsoft,
     metaContentHeight: ESTIMATED_CONTENT_HEIGHTS.meta,
     affiliationsContentHeight: ESTIMATED_CONTENT_HEIGHTS.affiliations,
+    actionsContentHeight: ESTIMATED_CONTENT_HEIGHTS.actions,
   };
 }
 
@@ -160,6 +174,10 @@ function resolveContentMotion(measurements: IntroContentMeasurements): IntroCont
     metaEndY: getMetaContentEndY(measurements.metaContentHeight, layoutReferenceHeight),
     affiliationsEndY: getAffiliationsContentEndY(
       measurements.affiliationsContentHeight,
+      layoutReferenceHeight,
+    ),
+    actionsEndY: getActionsContentEndY(
+      measurements.actionsContentHeight,
       layoutReferenceHeight,
     ),
   };
@@ -209,9 +227,15 @@ function resolvePhaseDuration(
     case 'actionsScroll':
       return scrollDurationForEndY(
         ACTIONS_CONTENT_START_VH,
-        ACTIONS_CONTENT_END_Y,
+        motion.actionsEndY,
         getContentPhaseDuration(key, isMobile),
       );
+    case 'howLettersMove': {
+      const whoStoryDuration = getStoryChapterDuration(WHO_STORY_PHASES, isMobile);
+      const howCoreDuration = getStoryChapterDuration(HOW_STORY_CORE_PHASES, isMobile);
+      const minDuration = getIntroPhaseDuration('howLettersMove', isMobile);
+      return Math.max(minDuration, whoStoryDuration - howCoreDuration);
+    }
     default:
       if (key in OSR_INTRO_PHASE_DURATIONS) {
         return getIntroPhaseDuration(key as OsrIntroPhaseKey, isMobile);

--- a/components/home/osrIntroTimeline.ts
+++ b/components/home/osrIntroTimeline.ts
@@ -245,7 +245,7 @@ function resolvePhaseDuration(
 }
 
 /** Who copy fades in as soon as the typing hero is fully gone (parallel with whoSectionIn). */
-export function getWhoContentInScrollPhase(
+function getWhoContentInScrollPhase(
   typingFadeOutPhase: OsrScrollPhase,
   isMobile: boolean,
 ): OsrScrollPhase {

--- a/components/home/osrIntroTimeline.ts
+++ b/components/home/osrIntroTimeline.ts
@@ -5,6 +5,10 @@
  * Store only `durationPercent` per phase; `buildIntroScrollPhases` assigns `at`.
  *
  * Pattern for content sections: scroll → crossfade → scroll → crossfade …
+ *
+ * Parallel phases (same scroll window as another beat, not in PHASE_ORDER):
+ * - `whoContentIn` — starts when typing hero is fully gone
+ * - page indicator — see getPageIndicatorScrollPhase()
  */
 import {
   ACTIONS_CONTENT_END_Y,
@@ -69,12 +73,11 @@ const OSR_CONTENT_PHASE_DURATIONS_MOBILE: Partial<
   actionsScroll: 36,
 };
 
-/** Scroll story order — must match scene attachment in OsrIntroScroll.tsx. */
+/** Sequential scroll story — must match scene attachment in OsrIntroScroll.tsx. */
 const PHASE_ORDER = [
   'typingFadeOut',
   'whoSectionIn',
   'whoLettersMove',
-  'whoContentIn',
   'whoSectionOut',
   'howSectionIn',
   'howLettersMove',
@@ -92,7 +95,8 @@ const PHASE_ORDER = [
 
 type OsrIntroPhaseKey = keyof typeof OSR_INTRO_PHASE_DURATIONS;
 type OsrContentPhaseKey = keyof typeof OSR_CONTENT_PHASE_DURATIONS;
-type OsrPhaseKey = (typeof PHASE_ORDER)[number];
+type OsrSequentialPhaseKey = (typeof PHASE_ORDER)[number];
+export type OsrPhaseKey = OsrSequentialPhaseKey | 'whoContentIn';
 
 const STAGE_BASE_HEIGHT = 1080;
 const MOBILE_VIEWPORT_HEIGHT = 844;
@@ -173,7 +177,7 @@ function scrollDurationForEndY(
 }
 
 function resolvePhaseDuration(
-  key: OsrPhaseKey,
+  key: OsrSequentialPhaseKey,
   isMobile: boolean,
   motion: IntroContentMotion,
 ): number {
@@ -216,6 +220,25 @@ function resolvePhaseDuration(
   }
 }
 
+/** Who copy fades in as soon as the typing hero is fully gone (parallel with whoSectionIn). */
+export function getWhoContentInScrollPhase(
+  typingFadeOutPhase: OsrScrollPhase,
+  isMobile: boolean,
+): OsrScrollPhase {
+  return {
+    at: getPhaseEndVh(typingFadeOutPhase),
+    durationPercent: getIntroPhaseDuration('whoContentIn', isMobile),
+  };
+}
+
+/** Parallel intro phase — line scrolls through the unified intro story (Intro → How). */
+export function getPageIndicatorScrollPhase(howToWhoopPhase: OsrScrollPhase): OsrScrollPhase {
+  return {
+    at: 0,
+    durationPercent: getPhaseEndVh(howToWhoopPhase) * 100,
+  };
+}
+
 export function buildIntroScrollPhases(
   isMobile: boolean,
   measurements: IntroContentMeasurements,
@@ -233,6 +256,8 @@ export function buildIntroScrollPhases(
     phases[key] = { at, durationPercent };
     at = getPhaseEndVh(phases[key]);
   }
+
+  phases.whoContentIn = getWhoContentInScrollPhase(phases.typingFadeOut, isMobile);
 
   return { phases, motion, scrollTrackEndVh: getPhaseEndVh(phases.actionsScroll) };
 }

--- a/components/home/osrScrollUtils.ts
+++ b/components/home/osrScrollUtils.ts
@@ -52,10 +52,17 @@ export function getOsrSceneConfig(
 export const PERSONAL_BAR_CONTENT_START_VH = 140;
 export const PERSONAL_BAR_CONTENT_START_Y = `${PERSONAL_BAR_CONTENT_START_VH}vh`;
 
-/** Actions entry: one viewport below (not 140vh). Content scrolls up to y=0. */
-export const ACTIONS_CONTENT_START_VH = 100;
+/** Actions entry: just below the stage — contact rises in as affiliations exits. */
+export const ACTIONS_CONTENT_START_VH = 72;
 export const ACTIONS_CONTENT_START_Y = `${ACTIONS_CONTENT_START_VH}vh`;
-export const ACTIONS_CONTENT_END_Y = '0';
+
+/** Measure contact section content height (same pattern as personal bars). */
+export function measureActionsContentHeight(content: HTMLElement): number {
+  gsap.set(content, { y: 0 });
+  const height = Math.max(content.scrollHeight, content.getBoundingClientRect().height);
+  gsap.set(content, { y: ACTIONS_CONTENT_START_Y });
+  return height;
+}
 
 /** Measure personal-bar content height without transform affecting layout reads. */
 export function measurePersonalBarContentHeight(content: HTMLElement): number {
@@ -83,6 +90,24 @@ function parseNegativeVh(value: string): number {
 
 export function getPhaseEndVh(phase: { at: number; durationPercent: number }): number {
   return phase.at + phase.durationPercent / 100;
+}
+
+/**
+ * Furthest track-relative scroll (below-navbar vh).
+ * Track height uses full window vh; scene math uses viewport below navbar — this closes the gap.
+ */
+export function getScrollTrackBottomRelativeVh(scrollTrackEndVh: number): number {
+  const belowNav = getViewportBelowNavbar();
+  const maxPx = Math.max(0, scrollTrackEndVh * window.innerHeight - window.innerHeight);
+  return maxPx / belowNav;
+}
+
+/** Window scrollY that pins the scroll track to the page bottom. */
+export function getScrollTrackBottomPx(scrollTrack: HTMLElement): number {
+  return Math.max(
+    scrollTrack.offsetTop,
+    scrollTrack.offsetTop + scrollTrack.offsetHeight - window.innerHeight,
+  );
 }
 
 /** Vertical travel (vh) for a content scroll from `startVh` to `endY`. */
@@ -121,7 +146,20 @@ export function getAffiliationsContentEndY(
   viewportHeightPx: number,
 ): string {
   const contentVh = (contentHeightPx / viewportHeightPx) * 100;
-  const endVh = Math.max(20, Math.round(contentVh + 24));
+  const endVh = Math.max(15, Math.round(contentVh + 10));
   return `-${endVh}vh`;
+}
+
+/** Contact section — rest with the block's midpoint on screen, not its top edge. */
+const ACTIONS_CONTENT_MIDPOINT_VH = 40;
+
+export function getActionsContentEndY(
+  contentHeightPx: number,
+  stageHeightPx: number,
+): string {
+  const contentVh = (contentHeightPx / stageHeightPx) * 100;
+  if (contentVh >= 100) return '0';
+  const offsetVh = Math.round(ACTIONS_CONTENT_MIDPOINT_VH - contentVh / 2);
+  return `${Math.max(0, offsetVh)}vh`;
 }
 

--- a/components/home/staticIntroScrollNav.ts
+++ b/components/home/staticIntroScrollNav.ts
@@ -1,0 +1,137 @@
+import { getViewportOffsetTopPx } from './osrScrollUtils';
+
+export type StaticIntroNavSection = {
+  id: string;
+  label: string;
+  /** Document scroll target when the section is selected. */
+  scrollTargetId: string;
+  /** Element whose top marks when this section becomes active while scrolling. */
+  startElementId: string;
+  scrollToPageBottom?: boolean;
+};
+
+export const STATIC_INTRO_NAV_SECTIONS: StaticIntroNavSection[] = [
+  {
+    id: 'intro',
+    label: 'Intro',
+    scrollTargetId: 'intro-zero',
+    startElementId: 'intro-zero',
+  },
+  {
+    id: 'personal-bars',
+    label: 'Personal Bars',
+    scrollTargetId: 'whoop-bar-heading',
+    startElementId: 'intro-whoop-bar',
+  },
+  {
+    id: 'contact',
+    label: 'Contact',
+    scrollTargetId: 'intro-actions',
+    startElementId: 'intro-actions',
+    scrollToPageBottom: true,
+  },
+];
+
+export const STATIC_SECTION_SCROLL_MT =
+  'scroll-mt-[calc(var(--navbar-height)+var(--static-intro-nav-height,3.25rem)+0.5rem)]';
+
+function getElementDocumentTop(id: string): number | null {
+  const element = document.getElementById(id);
+  if (!element) return null;
+  return element.getBoundingClientRect().top + window.scrollY;
+}
+
+export function getStaticIntroNavHeaderOffsetPx(): number {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue('--static-intro-nav-height')
+    .trim();
+  const navHeight = raw.endsWith('px') ? parseFloat(raw) : 52;
+
+  return getViewportOffsetTopPx(0) + navHeight;
+}
+
+function getSectionRangeStart(section: StaticIntroNavSection, headerOffsetPx: number): number {
+  if (section.id === 'intro') return 0;
+  const top = getElementDocumentTop(section.startElementId);
+  if (top === null) return 0;
+  return Math.max(0, top - headerOffsetPx);
+}
+
+function getSectionRangeEnd(
+  sections: StaticIntroNavSection[],
+  index: number,
+  headerOffsetPx: number,
+): number {
+  const next = sections[index + 1];
+  if (next) return getSectionRangeStart(next, headerOffsetPx);
+  const contact = sections[sections.length - 1];
+  if (contact?.scrollToPageBottom) {
+    return Math.max(
+      document.documentElement.scrollHeight - window.innerHeight,
+      getSectionRangeStart(contact, headerOffsetPx),
+    );
+  }
+  return document.documentElement.scrollHeight - window.innerHeight;
+}
+
+export function getActiveStaticIntroNavId(
+  sections: StaticIntroNavSection[],
+  scrollY: number,
+  headerOffsetPx: number,
+): string {
+  if (sections.length === 0) return 'intro';
+
+  const referenceY = scrollY + headerOffsetPx * 0.35;
+  let active = sections[0].id;
+
+  for (const section of sections) {
+    const start = getSectionRangeStart(section, headerOffsetPx);
+    if (referenceY + 2 >= start) active = section.id;
+  }
+
+  return active;
+}
+
+export function getStaticIntroNavSectionProgress(
+  sections: StaticIntroNavSection[],
+  scrollY: number,
+  sectionId: string,
+  headerOffsetPx: number,
+): number {
+  const index = sections.findIndex((section) => section.id === sectionId);
+  if (index === -1) return 0;
+
+  const section = sections[index];
+  const start = getSectionRangeStart(section, headerOffsetPx);
+  const end = getSectionRangeEnd(sections, index, headerOffsetPx);
+  const span = end - start;
+  if (span <= 0) return 1;
+
+  return Math.min(1, Math.max(0, (scrollY - start) / span));
+}
+
+export function scrollToStaticIntroNavSection(
+  section: StaticIntroNavSection,
+  headerOffsetPx: number,
+): void {
+  if (section.scrollToPageBottom) {
+    window.scrollTo({
+      top: document.documentElement.scrollHeight,
+      behavior: 'smooth',
+    });
+    return;
+  }
+
+  if (section.id === 'intro') {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    return;
+  }
+
+  const targetTop = getElementDocumentTop(section.scrollTargetId);
+  if (targetTop === null) return;
+
+  window.scrollTo({
+    top: Math.max(0, targetTop - headerOffsetPx),
+    behavior: 'smooth',
+  });
+}


### PR DESCRIPTION
- Updated the jump navi to have only 3 options.
- Added 'gilroy' like effects for the jump navi.
- Made the mobile-static's jump navi horizontal and content won't clash with it by adding a white gradient behind it.
- Reactivated the animation for the typing hero page for mobile-static view.
- Added the action for users to sign up without directing them to use the top nav bar to sign up.

NOTES:
STILL A WORK IN PROGRESS