### PR TITLE
Resizing bug

### DIFF
--- a/components/home/OsrIntroScroll.tsx
+++ b/components/home/OsrIntroScroll.tsx
@@ -1018,6 +1018,9 @@ export function OsrIntroScroll() {
 
       if (lastCompactViewportRef.current === null || lastCompactViewportRef.current !== isCompact) {
         window.scrollTo(0, 0);
+        // Mode remount rebuilds the master timeline — skip the stageScale preserve sync
+        // that would otherwise remap mid-story progress onto new phase timings.
+        skipNextStageScaleSyncRef.current = true;
       }
       lastCompactViewportRef.current = isCompact;
 
@@ -1116,8 +1119,9 @@ export function OsrIntroScroll() {
       let pendingLayoutSyncRaf: number | null = null;
       let layoutScrollTrackEndVh = 0;
       let layoutSyncCancelled = false;
-      // Hard refresh / first paint: never preserve progress until the initial reset wave
-      // finishes. Browser restoration can land mid-page between scrollTo(0,0) and layout sync.
+      // Never preserve progress until the initial reset wave finishes. Browser restoration
+      // (and compact↔desktop remounts that jump to top) can land mid-page between
+      // scrollTo(0,0) and the first layout sync.
       let forceResetScroll = true;
 
       const scheduleLayoutSync = () => {
@@ -1192,6 +1196,29 @@ export function OsrIntroScroll() {
               clearProps: 'left,right,top,bottom',
             });
           };
+
+          const viewportHeight = getViewportBelowNavbar();
+          const { phases, motion, scrollTrackEndVh } = buildIntroScrollPhases(compactMode, {
+            viewportHeight,
+            whoopContentHeight: measurePersonalBarContentHeight(whoopPersonalBarContent),
+          });
+          const { whoopEndY: whoopContentEndY } = motion;
+
+          // Settle track height + scroll at progress 0 before start frames / ScrollTrigger
+          // create — otherwise ST initializes mid-page and scrub snaps layers twice.
+          applyScrollTrackHeight(scrollTrack, scrollTrackEndVh);
+          layoutScrollTrackEndVh = scrollTrackEndVh;
+          setScrollTrackEndVh(scrollTrackEndVh);
+          setIntroNavSections(
+            buildIntroNavSections({
+              whoopPersonalBarScroll: phases.whoopPersonalBarScroll,
+              actionsScroll: phases.actionsScroll,
+            }),
+          );
+          ScrollTrigger.clearScrollMemory();
+          window.scrollTo(0, 0);
+          ScrollTrigger.update();
+
           applyIntroStartFrame(
             sectionZero,
             sectionOne,
@@ -1221,24 +1248,6 @@ export function OsrIntroScroll() {
           if (agreementsScrollLine) {
             gsap.set(agreementsScrollLine, { opacity: 0, y: 0 });
           }
-          const viewportHeight = getViewportBelowNavbar();
-          const { phases, motion, scrollTrackEndVh } = buildIntroScrollPhases(compactMode, {
-            viewportHeight,
-            whoopContentHeight: measurePersonalBarContentHeight(whoopPersonalBarContent),
-          });
-          const { whoopEndY: whoopContentEndY } = motion;
-
-          // Apply track height directly (do not preserve progress — that re-locks browser-
-          // restored mid-page offsets after hard refresh).
-          applyScrollTrackHeight(scrollTrack, scrollTrackEndVh);
-          layoutScrollTrackEndVh = scrollTrackEndVh;
-          setScrollTrackEndVh(scrollTrackEndVh);
-          setIntroNavSections(
-            buildIntroNavSections({
-              whoopPersonalBarScroll: phases.whoopPersonalBarScroll,
-              actionsScroll: phases.actionsScroll,
-            }),
-          );
           resetWhoLetterStartFrame();
           resetHowLetterStartFrame();
           createPrimaryMasterTimeline({
@@ -1330,6 +1339,13 @@ export function OsrIntroScroll() {
         // while scrolling; avoid refreshing triggers unless layout width actually changes.
         if (isCompactViewport && !widthChanged) return;
 
+        // Crossing the compact threshold remounts GSAP with different phase timings —
+        // preserving progress against the dying timeline scrubs letters/copy haywire.
+        if (readIsCompactViewport(nextLayoutWidth) !== isCompactViewport) {
+          window.scrollTo(0, 0);
+          return;
+        }
+
         preserveScrollTrackProgress(scrollTrack, () => {
           if (layoutScrollTrackEndVh > 0) {
             applyScrollTrackHeight(scrollTrack, layoutScrollTrackEndVh);
@@ -1356,7 +1372,7 @@ export function OsrIntroScroll() {
         ScrollTrigger.clearScrollMemory();
       };
     },
-    { scope: introRootRef, dependencies: [isCompactViewport] },
+    { scope: introRootRef, dependencies: [isCompactViewport], revertOnUpdate: true },
   );
 
   const useFixedStage = !isCompactViewport;

--- a/components/home/OsrIntroScroll.tsx
+++ b/components/home/OsrIntroScroll.tsx
@@ -1001,19 +1001,14 @@ export function OsrIntroScroll() {
 
   // Manual restoration must live for the whole intro mount. Putting it inside useGSAP
   // restores `auto` on compact↔desktop rebuilds and lets the browser reapply mid-page scroll.
+  // Do not restore `auto` on unmount either — React Strict Mode teardown briefly flips it
+  // back and the browser can re-lock a mid-page offset before remount sets manual again.
   useLayoutEffect(() => {
-    const previous =
-      'scrollRestoration' in window.history ? window.history.scrollRestoration : null;
     if ('scrollRestoration' in window.history) {
       window.history.scrollRestoration = 'manual';
     }
     ScrollTrigger.clearScrollMemory();
     window.scrollTo(0, 0);
-    return () => {
-      if (previous !== null) {
-        window.history.scrollRestoration = previous;
-      }
-    };
   }, []);
 
   useLayoutEffect(() => {
@@ -1120,18 +1115,37 @@ export function OsrIntroScroll() {
       const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
       let pendingLayoutSyncRaf: number | null = null;
       let layoutScrollTrackEndVh = 0;
+      let layoutSyncCancelled = false;
+      // Hard refresh / first paint: never preserve progress until the initial reset wave
+      // finishes. Browser restoration can land mid-page between scrollTo(0,0) and layout sync.
+      let forceResetScroll = true;
 
       const scheduleLayoutSync = () => {
         if (pendingLayoutSyncRaf !== null) return;
         pendingLayoutSyncRaf = requestAnimationFrame(() => {
           pendingLayoutSyncRaf = null;
-          preserveScrollTrackProgress(scrollTrack, () => {
+          if (layoutSyncCancelled) return;
+
+          const resetScroll = forceResetScroll;
+          const applyLayout = () => {
             if (layoutScrollTrackEndVh > 0) {
               applyScrollTrackHeight(scrollTrack, layoutScrollTrackEndVh);
             }
             ScrollTrigger.refresh(true);
-          });
+          };
+
+          if (resetScroll) {
+            applyLayout();
+            window.scrollTo(0, 0);
+          } else {
+            preserveScrollTrackProgress(scrollTrack, applyLayout);
+          }
+
           requestAnimationFrame(() => {
+            if (layoutSyncCancelled) return;
+            if (resetScroll) {
+              window.scrollTo(0, 0);
+            }
             ScrollTrigger.update();
             syncScrollTrackAnimations(scrollTrack);
           });
@@ -1154,7 +1168,11 @@ export function OsrIntroScroll() {
         }
         gsap.set(sectionActions, { opacity: 1, pointerEvents: 'auto' });
         if (pageIndicator) gsap.set(pageIndicator, { opacity: 0 });
-        return;
+        forceResetScroll = false;
+        return () => {
+          layoutSyncCancelled = true;
+          scheduleLayoutSyncRef.current = null;
+        };
       }
 
       const ctx = gsap.context(() => {
@@ -1272,13 +1290,32 @@ export function OsrIntroScroll() {
       }, introRoot);
 
       scheduleLayoutSync();
-      document.fonts?.ready.then(scheduleLayoutSync);
+      const endInitialScrollReset = () => {
+        // Wait until after any queued reset syncs flush before preserving progress.
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            if (!layoutSyncCancelled) forceResetScroll = false;
+          });
+        });
+      };
+      if (document.fonts?.ready) {
+        void document.fonts.ready.then(() => {
+          if (layoutSyncCancelled) return;
+          scheduleLayoutSync();
+          endInitialScrollReset();
+        });
+      } else {
+        endInitialScrollReset();
+      }
 
       // bfcache restores can ignore manual scrollRestoration; reset only then.
       const onPageShow = (event: PageTransitionEvent) => {
         if (!event.persisted) return;
+        forceResetScroll = true;
         window.scrollTo(0, 0);
         syncScrollTrackAnimations(scrollTrack);
+        scheduleLayoutSync();
+        endInitialScrollReset();
       };
       window.addEventListener('pageshow', onPageShow);
 
@@ -1306,6 +1343,7 @@ export function OsrIntroScroll() {
       window.addEventListener('resize', onWindowResize);
 
       return () => {
+        layoutSyncCancelled = true;
         if (pendingLayoutSyncRaf !== null) {
           cancelAnimationFrame(pendingLayoutSyncRaf);
           pendingLayoutSyncRaf = null;


### PR DESCRIPTION
Transitions between desktop to mobile were causing several parallax effects to go haywire. Content were fading in and out while still in view, the flying letters were resetting its position in view, all while scrolling.

- Fixed issue that the GSAP timeline were not properly rebuilt between transtitions.
- When transitioning, the scrolltrack should reset to the top now, previously it was not after adding the revamp personal bar PR.

This is a constant _**edge case**_ bug, this bug may come up again in a another edge case we didn't think about.